### PR TITLE
Make all db pointers/indexes read/write atomic.

### DIFF
--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -49,7 +49,7 @@ public:
         store(const path& prefix);
         bool touch_all() const;
 
-        path db_lock;
+        path database_lock;
         path blocks_lookup;
         path blocks_index;
         path history_lookup;
@@ -57,7 +57,7 @@ public:
         path stealth_index;
         path stealth_rows;
         path spends_lookup;
-        path txs_lookup;
+        path transactions_lookup;
     };
 
     /// Create a new database with a given path prefix and default paths.

--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <memory>
 #include <boost/filesystem.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <bitcoin/bitcoin.hpp>
@@ -115,6 +116,7 @@ private:
     typedef std::atomic<size_t> sequential_lock;
     typedef boost::interprocess::file_lock file_lock;
 
+    static void uninitialize_lock(const path& lock);
     static file_lock initialize_lock(const path& lock);
 
     void synchronize();
@@ -127,11 +129,12 @@ private:
     void pop_inputs(const inputs& inputs, size_t height);
     void pop_outputs(const outputs& outputs, size_t height);
 
+    const path lock_file_path_;
     const size_t history_height_;
     const size_t stealth_height_;
 
-    file_lock file_lock_;
     sequential_lock sequential_lock_;
+    std::shared_ptr<file_lock> file_lock_;
 };
 
 } // namespace database

--- a/include/bitcoin/database/impl/hash_table_header.ipp
+++ b/include/bitcoin/database/impl/hash_table_header.ipp
@@ -103,9 +103,12 @@ ValueType hash_table_header<IndexType, ValueType>::read(IndexType index) const
     // The accessor must remain in scope until the end of the block.
     const auto memory = file_.access();
     const auto value_address = REMAP_ADDRESS(memory) + item_position(index);
-    //*************************************************************************
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
     return from_little_endian_unsafe<ValueType>(value_address);
-    //*************************************************************************
+    ///////////////////////////////////////////////////////////////////////////
 }
 
 template <typename IndexType, typename ValueType>
@@ -119,9 +122,12 @@ void hash_table_header<IndexType, ValueType>::write(IndexType index,
     const auto memory = file_.access();
     const auto value_address = REMAP_ADDRESS(memory) + item_position(index);
     auto serial = make_serializer(value_address);
-    //*************************************************************************
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    unique_lock(mutex_);
     serial.template write_little_endian<ValueType>(value);
-    //*************************************************************************
+    ///////////////////////////////////////////////////////////////////////////
 }
 
 template <typename IndexType, typename ValueType>

--- a/include/bitcoin/database/primitives/hash_table_header.hpp
+++ b/include/bitcoin/database/primitives/hash_table_header.hpp
@@ -36,7 +36,7 @@ namespace database {
  *  [ [ item:ValueType ] ]
  *  [ [      ...       ] ]
  *
- * Empty elements are represented by the value array.empty
+ * Empty elements are represented by the value hash_table_header.empty
  */
 template <typename IndexType, typename ValueType>
 class hash_table_header
@@ -71,6 +71,7 @@ private:
 
     memory_map& file_;
     IndexType buckets_;
+    mutable shared_mutex mutex_;
 };
 
 } // namespace database

--- a/include/bitcoin/database/primitives/record_multimap.hpp
+++ b/include/bitcoin/database/primitives/record_multimap.hpp
@@ -74,6 +74,7 @@ private:
 
     record_hash_table_type& map_;
     record_list& records_;
+    mutable shared_mutex mutex_;
 };
 
 } // namespace database

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -47,7 +47,7 @@ bool data_base::touch_file(const path& file_path)
         return false;
 
     // Write one byte so file is nonzero size.
-    file.write("H", 1);
+    file.write("X", 1);
     return true;
 }
 
@@ -70,21 +70,22 @@ bool data_base::initialize(const path& prefix, const chain::block& genesis)
 
 data_base::store::store(const path& prefix)
 {
-    // Hash-based loookup (hash tables).
-    blocks_lookup = prefix / "blocks_lookup";
-    history_lookup = prefix / "history_lookup";
-    spends_lookup = prefix / "spends_lookup";
-    txs_lookup = prefix / "txs_lookup";
+    // Hash-based lookup (hash tables).
+    blocks_lookup = prefix / "block_table";
+    history_lookup = prefix / "history_table";
+    spends_lookup = prefix / "spend_table";
+    transactions_lookup = prefix / "transaction_table";
 
     // Height-based (reverse) lookup.
-    blocks_index = prefix / "blocks_index";
+    blocks_index = prefix / "block_index";
     stealth_index = prefix / "stealth_index";
 
     // One (address) to many (rows).
     history_rows = prefix / "history_rows";
     stealth_rows = prefix / "stealth_rows";
 
-    db_lock = prefix / "db_lock";
+    // 
+    database_lock = prefix / "database_lock";
 }
 
 bool data_base::store::touch_all() const
@@ -97,7 +98,7 @@ bool data_base::store::touch_all() const
         touch_file(stealth_index) &&
         touch_file(stealth_rows) &&
         touch_file(spends_lookup) &&
-        touch_file(txs_lookup);
+        touch_file(transactions_lookup);
 }
 
 data_base::file_lock data_base::initialize_lock(const path& lock)
@@ -132,10 +133,10 @@ data_base::data_base(const store& paths, size_t history_height,
     history(paths.history_lookup, paths.history_rows),
     stealth(paths.stealth_index, paths.stealth_rows),
     spends(paths.spends_lookup),
-    transactions(paths.txs_lookup),
+    transactions(paths.transactions_lookup),
     history_height_(history_height),
     stealth_height_(stealth_height),
-    file_lock_(initialize_lock(paths.db_lock)),
+    file_lock_(initialize_lock(paths.database_lock)),
     sequential_lock_(0)
 {
 }

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -70,17 +70,17 @@ bool data_base::initialize(const path& prefix, const chain::block& genesis)
 
 data_base::store::store(const path& prefix)
 {
-    // Hash tables.
+    // Hash-based loookup (hash tables).
     blocks_lookup = prefix / "blocks_lookup";
     history_lookup = prefix / "history_lookup";
     spends_lookup = prefix / "spends_lookup";
     txs_lookup = prefix / "txs_lookup";
 
-    // Arrays.
+    // Height-based (reverse) lookup.
     blocks_index = prefix / "blocks_index";
     stealth_index = prefix / "stealth_index";
 
-    // Lists.
+    // One (address) to many (rows).
     history_rows = prefix / "history_rows";
     stealth_rows = prefix / "stealth_rows";
 

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -98,8 +98,7 @@ block_result block_database::get(const hash_digest& hash) const
 
 void block_database::store(const block& block)
 {
-    const auto height = index_manager_.count();
-    store(block, height);
+    store(block, index_manager_.count());
 }
 
 void block_database::store(const block& block, size_t height)

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -105,10 +105,10 @@ void block_database::store(const block& block, size_t height)
 {
     BITCOIN_ASSERT(height <= max_uint32);
     const auto height32 = static_cast<uint32_t>(height);
-    const auto number_txs = block.transactions.size();
+    const auto tx_count = block.transactions.size();
 
-    BITCOIN_ASSERT(number_txs <= max_uint32);
-    const auto number_txs32 = static_cast<uint32_t>(number_txs);
+    BITCOIN_ASSERT(tx_count <= max_uint32);
+    const auto tx_count32 = static_cast<uint32_t>(tx_count);
 
     // Write block data.
     const auto write = [&](memory_ptr data)
@@ -117,17 +117,14 @@ void block_database::store(const block& block, size_t height)
         const auto header_data = block.header.to_data(false);
         serial.write_data(header_data);
         serial.write_4_bytes_little_endian(height32);
-        serial.write_4_bytes_little_endian(number_txs32);
+        serial.write_4_bytes_little_endian(tx_count32);
 
         for (const auto& tx: block.transactions)
-        {
-            const auto tx_hash = tx.hash();
-            serial.write_hash(tx_hash);
-        }
+            serial.write_hash(tx.hash());
     };
 
     const auto key = block.header.hash();
-    const auto value_size = 80 + 4 + 4 + number_txs * hash_size;
+    const auto value_size = 80 + 4 + 4 + tx_count * hash_size;
     const auto position = lookup_map_.store(key, write, value_size);
 
     // Write height -> position mapping.


### PR DESCRIPTION
Resolves: https://github.com/libbitcoin/libbitcoin-database/issues/4

The locking which produces the atomicity is not fully optimal, since all reads of pointers or indexes in a given database are blocked by a write of any pointer/index in the in the same context. However this is not a material performance hit given the infrequency of writes except during sync and the trivial length of the 4/8 byte write under the lock. There was no impact to measured performance during a parallel sync run.