### PR TITLE
Remove stealth height index and substitute height field.

### DIFF
--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -55,7 +55,6 @@ public:
         path blocks_index;
         path history_lookup;
         path history_rows;
-        path stealth_index;
         path stealth_rows;
         path spends_lookup;
         path transactions_lookup;

--- a/include/bitcoin/database/databases/block_database.hpp
+++ b/include/bitcoin/database/databases/block_database.hpp
@@ -65,7 +65,7 @@ public:
     void store(const chain::block& block, size_t height);
 
     /// Unlink all blocks upwards from (and including) from_height.
-    void unlink(const size_t from_height);
+    void unlink(size_t from_height);
 
     /// Synchronise storage with disk so things are consistent.
     /// Should be done at the end of every block write.
@@ -81,10 +81,10 @@ private:
     typedef slab_hash_table<hash_digest> slab_map;
 
     /// Write block hash table position into the block index.
-    void write_position(const file_offset position, uint32_t height);
+    void write_position(file_offset position, array_index height);
 
-    /// Use block index to get block hasjh table position from height.
-    file_offset read_position(const array_index index) const;
+    /// Use block index to get block hash table position from height.
+    file_offset read_position(array_index height) const;
 
     /// Hash table used for looking up blocks by hash.
     memory_map lookup_file_;

--- a/include/bitcoin/database/databases/history_database.hpp
+++ b/include/bitcoin/database/databases/history_database.hpp
@@ -61,13 +61,11 @@ public:
     /// Call stop to unload the memory map.
     bool stop();
 
-    /// Add another row value to the key. If key doesn't exist then
-    /// it will be created.
+    /// Add a row value to the key. If key doesn't exist it will be created.
     void add_output(const short_hash& key, const chain::output_point& outpoint,
         const uint32_t output_height, uint64_t value);
 
-    /// Add another row value to the key. If key doesn't exist then
-    /// it will be created.
+    /// Add a row value to the key. If key doesn't exist it will be created.
     void add_spend(const short_hash& key, const chain::output_point& previous,
         const chain::input_point& spend, size_t spend_height);
 

--- a/include/bitcoin/database/databases/stealth_database.hpp
+++ b/include/bitcoin/database/databases/stealth_database.hpp
@@ -36,8 +36,7 @@ class BCD_API stealth_database
 public:
     typedef std::function<void(memory_ptr)> write_function;
 
-    stealth_database(const boost::filesystem::path& index_filename,
-        const boost::filesystem::path& rows_filename,
+    stealth_database(const boost::filesystem::path& rows_filename,
         std::shared_ptr<shared_mutex> mutex=nullptr);
 
     /// Initialize a new stealth database.
@@ -49,13 +48,14 @@ public:
     /// Call stop to unload the memory map.
     bool stop();
 
-    /// Linearly scan all entries starting at from_height.
+    /// Linearly scan all entries, discarding those after from_height.
     chain::stealth scan(const binary& filter, size_t from_height) const;
 
     /// Add a stealth row to the database.
-    void store(uint32_t prefix, const chain::stealth_row& row);
+    void store(uint32_t prefix, uint32_t height,
+        const chain::stealth_row& row);
 
-    /// Delete all rows after and including from_height.
+    /// Delete all rows after and including from_height (no implemented).
     void unlink(size_t from_height);
 
     /// Synchronise storage with disk so things are consistent.
@@ -66,14 +66,7 @@ private:
     void write_index();
     array_index read_index(size_t from_height) const;
 
-    array_index row_count_;
-
-    // Table used for jumping to rows by height.
-    // Resolves to a index within the rows.
-    memory_map index_file_;
-    record_manager index_manager_;
-
-    // Actual row entries containing stealth tx data.
+    // Row entries containing stealth tx data.
     memory_map rows_file_;
     record_manager rows_manager_;
 };

--- a/src/databases/history_database.cpp
+++ b/src/databases/history_database.cpp
@@ -173,6 +173,7 @@ history history_database::get(const short_hash& key, size_t limit,
             result.emplace_back(read_row(address));
     }
 
+    // TODO: we could sort result here.
     return result;
 }
 

--- a/src/databases/stealth_database.cpp
+++ b/src/databases/stealth_database.cpp
@@ -32,63 +32,61 @@ namespace database {
 using namespace boost::filesystem;
 using namespace bc::chain;
 
-// ephemkey is without sign byte and address is without version byte.
+constexpr size_t height_size = sizeof(uint32_t);
 constexpr size_t prefix_size = sizeof(uint32_t);
 
-// [ prefix_bitfield:4 ][ ephemkey:32 ][ address:20 ][ tx_id:32 ]
-constexpr size_t row_size = prefix_size + 2 * hash_size + short_hash_size;
+// ephemkey is without sign byte and address is without version byte.
+// [ prefix_bitfield:4 ][ height:32 ][ ephemkey:32 ][ address:20 ][ tx_id:32 ]
+constexpr size_t row_size = prefix_size + height_size + hash_size +
+    short_hash_size + hash_size;
 
-stealth_database::stealth_database(const path& index_filename,
-    const path& rows_filename, std::shared_ptr<shared_mutex> mutex)
-  : index_file_(index_filename, mutex),
-    index_manager_(index_file_, 0, sizeof(array_index)),
-    rows_file_(rows_filename, mutex),
+stealth_database::stealth_database(const path& rows_filename,
+    std::shared_ptr<shared_mutex> mutex)
+  : rows_file_(rows_filename, mutex),
     rows_manager_(rows_file_, 0, row_size)
 {
 }
 
 void stealth_database::create()
 {
-    index_file_.resize(minimum_records_size);
-    index_manager_.create();
     rows_file_.resize(minimum_records_size);
     rows_manager_.create();
 }
 
 void stealth_database::start()
 {
-    index_manager_.start();
     rows_manager_.start();
-    row_count_ = rows_manager_.count();
 }
 
 bool stealth_database::stop()
 {
-    return index_file_.stop() && rows_file_.stop();
+    return rows_file_.stop();
 }
 
-// Stealth records are not indexed. The prefix is fixed at 32 bits, but the
-// filter is 0-32 bits, so the records cannot be indexed using a hash table.
+// The prefix is fixed at 32 bits, but the filter is 0-32 bits, so the records
+// cannot be indexed using a hash table. We also do not index by height.
 stealth stealth_database::scan(const binary& filter, size_t from_height) const
 {
     stealth result;
 
-    if (from_height >= index_manager_.count())
-        return result;
-
-    const auto start = read_index(from_height);
-
-    for (auto index = start; index < rows_manager_.count(); ++index)
+    for (auto row = 0; row < rows_manager_.count(); ++row)
     {
-        // see if prefix matches
-        const auto memory = rows_manager_.get(index);
-        const auto record = REMAP_ADDRESS(memory);
+        const auto memory = rows_manager_.get(row);
+        auto record = REMAP_ADDRESS(memory);
+
+        // Skip if prefix doesn't match.
         const auto field = from_little_endian_unsafe<uint32_t>(record);
         if (!filter.is_prefix_of(field))
             continue;
 
+        // Skip if height is too low.
+        record += prefix_size;
+        const auto height = from_little_endian_unsafe<uint32_t>(record);
+        if (height < from_height)
+            continue;
+
         // Add row to results.
-        auto deserial = make_deserializer_unsafe(record + prefix_size);
+        auto deserial = make_deserializer_unsafe(record + height_size);
         result.push_back(
         {
             deserial.read_hash(),
@@ -97,10 +95,12 @@ stealth stealth_database::scan(const binary& filter, size_t from_height) const
         });
     }
 
+    // TODO: we could sort result here.
     return result;
 }
 
-void stealth_database::store(uint32_t prefix, const stealth_row& row)
+void stealth_database::store(uint32_t prefix, uint32_t height,
+    const stealth_row& row)
 {
     // Allocate new row.
     const auto index = rows_manager_.new_records(1);
@@ -109,45 +109,25 @@ void stealth_database::store(uint32_t prefix, const stealth_row& row)
 
     // Write data.
     auto serial = make_serializer(data);
+
+    // Dual key.
     serial.write_4_bytes_little_endian(prefix);
+    serial.write_4_bytes_little_endian(height);
+
+    // Stealth data.
     serial.write_hash(row.ephemeral_key);
     serial.write_short_hash(row.address);
     serial.write_hash(row.transaction_hash);
-
-    write_index();
-
-    BITCOIN_ASSERT(serial.iterator() == data + prefix_size + hash_size +
-        short_hash_size + hash_size);
 }
 
-void stealth_database::unlink(size_t from_height)
+void stealth_database::unlink(size_t /* from_height */)
 {
-    if (index_manager_.count() > from_height)
-        index_manager_.set_count(from_height);
+    // TODO: scan by height and mark as deleted.
 }
 
 void stealth_database::sync()
 {
     rows_manager_.sync();
-    index_manager_.sync();
-}
-
-// Read/write of this value protected by sync.
-void stealth_database::write_index()
-{
-    const auto index = index_manager_.new_records(1);
-    const auto memory = index_manager_.get(index);
-    auto serial = make_serializer(REMAP_ADDRESS(memory));
-    serial.write_4_bytes_little_endian(row_count_);
-    row_count_ = rows_manager_.count();
-}
-
-array_index stealth_database::read_index(size_t from_height) const
-{
-    BITCOIN_ASSERT(from_height < index_manager_.count());
-    const auto memory = index_manager_.get(from_height);
-    const auto address = REMAP_ADDRESS(memory);
-    return from_little_endian_unsafe<array_index>(address);
 }
 
 } // namespace database

--- a/src/databases/stealth_database.cpp
+++ b/src/databases/stealth_database.cpp
@@ -69,7 +69,7 @@ stealth stealth_database::scan(const binary& filter, size_t from_height) const
 {
     stealth result;
 
-    for (auto row = 0; row < rows_manager_.count(); ++row)
+    for (array_index row = 0; row < rows_manager_.count(); ++row)
     {
         const auto memory = rows_manager_.get(row);
         auto record = REMAP_ADDRESS(memory);


### PR DESCRIPTION
The height index was entirely dysfunctional. The retains original intended functionality and fixes incorrect start_height queries. It does not remove stealth rows following a reorg.