### PR TITLE
Change tx position from 4 bytes to 2 bytes, comments.

### DIFF
--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -36,14 +36,11 @@ static constexpr auto index_header_size = 0u;
 static constexpr auto index_record_size = sizeof(file_offset);
 
 // Record format:
-// main:
-//  [ header:80      ]
-//  [ height:4       ]
-//  [ number_txs:1-8 ]
-// hashes:
-//  [ [    ...     ] ]
-//  [ [ tx_hash:32 ] ]
-//  [ [    ...     ] ]
+//  [ header:80 ]
+//  [ height:4 ]
+//  TODO: [ checksum:4 ] (store all zeros if not computed).
+//  [ tx_count:1-2 ]
+//  [ [ tx_hash:32 ]... ]
 
 // Blocks uses a hash table and an array index, both O(1).
 block_database::block_database(const path& map_filename,

--- a/src/databases/stealth_database.cpp
+++ b/src/databases/stealth_database.cpp
@@ -33,8 +33,12 @@ static constexpr auto rows_header_size = 0u;
 static constexpr auto height_size = sizeof(uint32_t);
 static constexpr auto prefix_size = sizeof(uint32_t);
 
+// [ prefix:4 ]
+// [ height:4 ]
+// [ ephemkey:32 ]
+// [ address:20 ]
+// [ tx_hash:32 ]
 // ephemkey is without sign byte and address is without version byte.
-// [ prefix_bitfield:4 ][ height:32 ][ ephemkey:32 ][ address:20 ][ tx_id:32 ]
 static constexpr auto row_size = prefix_size + height_size + hash_size +
     short_hash_size + hash_size;
 

--- a/src/result/block_result.cpp
+++ b/src/result/block_result.cpp
@@ -123,6 +123,7 @@ size_t block_result::transaction_count() const
     return deserial.read_size_little_endian();
 }
 
+// TODO: add method to read the full set of tx hashes in one call.
 hash_digest block_result::transaction_hash(size_t index) const
 {
     BITCOIN_ASSERT(slab_);

--- a/src/result/transaction_result.cpp
+++ b/src/result/transaction_result.cpp
@@ -34,7 +34,7 @@ static constexpr size_t value_size = sizeof(uint64_t);
 static constexpr size_t height_size = sizeof(uint32_t);
 static constexpr size_t version_size = sizeof(uint32_t);
 static constexpr size_t locktime_size = sizeof(uint32_t);
-static constexpr size_t position_size = sizeof(uint32_t);
+static constexpr size_t position_size = sizeof(uint16_t);
 
 transaction_result::transaction_result(const memory_ptr slab)
   : slab_(slab), hash_(null_hash)
@@ -79,7 +79,7 @@ size_t transaction_result::position() const
 {
     BITCOIN_ASSERT(slab_);
     const auto memory = REMAP_ADDRESS(slab_);
-    return from_little_endian_unsafe<uint32_t>(memory + height_size);
+    return from_little_endian_unsafe<uint16_t>(memory + height_size);
 }
 
 bool transaction_result::is_spent(size_t fork_height) const
@@ -90,7 +90,7 @@ bool transaction_result::is_spent(size_t fork_height) const
     const auto memory = REMAP_ADDRESS(slab_);
     const auto position_start = memory + height_size;
     auto deserial = make_unsafe_deserializer(position_start);
-    const auto position = deserial.read_4_bytes_little_endian();
+    const auto position = deserial.read_2_bytes_little_endian();
 
     // Cannot be spent if unconfirmed.
     if (position == transaction_database::unconfirmed)


### PR DESCRIPTION
This will save ~1GB disk space in the tx store. It is also a format break with previous stored, though this is already manifested in v3.1 - so this is taking advantage of the existing break.