### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -43,7 +43,7 @@ class BCD_API data_base
 public:
     typedef std::function<void(const code&)> result_handler;
 
-    data_base(const settings& settings, const bc::settings& bitocin_settings);
+    data_base(const settings& settings);
 
     // Open and close.
     // ------------------------------------------------------------------------
@@ -157,7 +157,6 @@ private:
 
     std::atomic<bool> closed_;
     const settings& settings_;
-    const bc::settings& bitcoin_settings_;
 
     // Used to prevent unsafe concurrent writes.
     mutable shared_mutex write_mutex_;

--- a/include/bitcoin/database/databases/block_database.hpp
+++ b/include/bitcoin/database/databases/block_database.hpp
@@ -44,7 +44,7 @@ public:
     block_database(const path& map_filename,
         const path& candidate_index_filename,
         const path& confirmed_index_filename, const path& tx_index_filename,
-        size_t buckets, size_t expansion, const bc::settings& bitcoin_settings);
+        size_t buckets, size_t expansion);
 
     /// Close the database (all threads must first be stopped).
     ~block_database();
@@ -141,8 +141,6 @@ private:
     // This indexes txs (vs. blocks) so the link type may be differentiated.
     file_storage tx_index_file_;
     manager_type tx_index_;
-
-    const bc::settings& bitcoin_settings_;
 
     // This provides atomicity for checksum, tx_start, tx_count, state.
     mutable shared_mutex metadata_mutex_;

--- a/include/bitcoin/database/result/block_result.hpp
+++ b/include/bitcoin/database/result/block_result.hpp
@@ -43,8 +43,7 @@ public:
         const_element_type;
 
     block_result(const const_element_type& element,
-        shared_mutex& metadata_mutex, const manager& index_manager,
-        const bc::settings& bitcoin_settings);
+        shared_mutex& metadata_mutex, const manager& index_manager);
 
     /// True if the requested block exists.
     operator bool() const;

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -57,11 +57,9 @@ using namespace bc::wallet;
 // Construct.
 // ----------------------------------------------------------------------------
 
-data_base::data_base(const settings& settings,
-    const bc::settings& bitcoin_settings)
+data_base::data_base(const settings& settings)
   : closed_(true),
     settings_(settings),
-    bitcoin_settings_(bitcoin_settings),
     database::store(settings.directory, settings.index_addresses,
         settings.flush_writes)
 {
@@ -137,7 +135,7 @@ void data_base::start()
 {
     blocks_ = std::make_shared<block_database>(block_table, candidate_index,
         confirmed_index, transaction_index, settings_.block_table_buckets,
-        settings_.file_growth_rate, bitcoin_settings_);
+        settings_.file_growth_rate);
 
     transactions_ = std::make_shared<transaction_database>(transaction_table,
         settings_.transaction_table_buckets, settings_.file_growth_rate,
@@ -526,7 +524,7 @@ bool data_base::pop_above(header_const_ptr_list_ptr headers,
     // Pop all headers above the fork point.
     for (size_t height = top; height > fork; --height)
     {
-        const auto next = std::make_shared<message::header>(bitcoin_settings_);
+        const auto next = std::make_shared<message::header>();
         if ((ec = pop_header(*next, height)))
             return false;
 
@@ -647,7 +645,7 @@ bool data_base::pop_above(block_const_ptr_list_ptr blocks,
     // Pop all blocks above the fork point.
     for (size_t height = top; height > fork; --height)
     {
-        const auto next = std::make_shared<message::block>(bitcoin_settings_);
+        const auto next = std::make_shared<message::block>();
         if ((ec = pop_block(*next, height)))
             return false;
 

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -75,8 +75,7 @@ static const auto block_size = header_size + median_time_past_size +
 // The block database keys off of block hash and has block value.
 block_database::block_database(const path& map_filename,
     const path& candidate_index_filename, const path& confirmed_index_filename,
-    const path& tx_index_filename, size_t buckets, size_t expansion,
-    const bc::settings& bitcoin_settings)
+    const path& tx_index_filename, size_t buckets, size_t expansion)
   : hash_table_file_(map_filename, expansion),
     hash_table_(hash_table_file_, buckets, block_size),
 
@@ -90,8 +89,7 @@ block_database::block_database(const path& map_filename,
 
     // Array storage.
     tx_index_file_(tx_index_filename, expansion),
-    tx_index_(tx_index_file_, 0, sizeof(file_offset)),
-    bitcoin_settings_(bitcoin_settings)
+    tx_index_(tx_index_file_, 0, sizeof(file_offset))
 {
 }
 
@@ -178,8 +176,7 @@ block_result block_database::get(size_t height, bool candidate) const
     {
         hash_table_.find(link),
         metadata_mutex_,
-        tx_index_,
-        bitcoin_settings_
+        tx_index_
     };
 }
 
@@ -190,8 +187,7 @@ block_result block_database::get(const hash_digest& hash) const
     {
         hash_table_.find(hash),
         metadata_mutex_,
-        tx_index_,
-        bitcoin_settings_
+        tx_index_
     };
 }
 

--- a/src/result/block_result.cpp
+++ b/src/result/block_result.cpp
@@ -49,10 +49,8 @@ static const auto transactions_offset = checksum_offset + checksum_size;
 static constexpr auto no_checksum = 0u;
 
 block_result::block_result(const const_element_type& element,
-    shared_mutex& metadata_mutex, const manager& index_manager,
-    const bc::settings& bitcoin_settings)
+    shared_mutex& metadata_mutex, const manager& index_manager)
   : height_(0),
-    header_(bitcoin_settings),
     median_time_past_(0),
     state_(block_state::missing),
     checksum_(no_checksum),

--- a/test/databases/block_database.cpp
+++ b/test/databases/block_database.cpp
@@ -31,8 +31,8 @@ using namespace bc::database;
 
 transaction random_tx(size_t fudge)
 {
-    static const chain::block genesis = bc::settings(bc::config::settings::mainnet)
-        .genesis_block;
+    static const auto settings = bc::settings(bc::config::settings::mainnet);
+    static const chain::block genesis = settings.genesis_block;
     auto tx = genesis.transactions()[0];
     tx.inputs()[0].previous_output().set_index(fudge);
     tx.metadata.link = fudge;
@@ -54,7 +54,7 @@ BOOST_FIXTURE_TEST_SUITE(database_tests, block_database_directory_setup_fixture)
 BOOST_AUTO_TEST_CASE(block_database__test)
 {
     // TODO: replace.
-    ////auto block0 = block::genesis_mainnet(bc::settings());
+    ////auto block0 = block::genesis_mainnet();
     ////block0.set_transactions(
     ////{
     ////    random_tx(0),
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h0 = block0.hash();
 
-    ////block block1(bc::settings{});
+    ////block block1;
     ////block1.set_header(block0.header());
     ////block1.header().set_nonce(4);
     ////block1.set_transactions(
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h1 = block1.hash();
 
-    ////block block2(bc::settings{});
+    ////block block2;
     ////block2.set_header(block0.header());
     ////block2.header().set_nonce(110);
     ////block2.set_transactions(
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h2 = block2.hash();
 
-    ////block block3(bc::settings{});
+    ////block block3;
     ////block3.set_header(block0.header());
     ////block3.header().set_nonce(88);
     ////block3.set_transactions(
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h3 = block3.hash();
 
-    ////block block4a(bc::settings{});
+    ////block block4a;
     ////block4a.set_header(block0.header());
     ////block4a.header().set_nonce(63);
     ////block4a.set_transactions(
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h4a = block4a.hash();
 
-    ////block block4b(bc::settings{});
+    ////block block4b;
     ////block4b.set_header(block0.header());
     ////block4b.header().set_nonce(633);
     ////block4b.set_transactions(
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h4b = block4b.hash();
 
-    ////block block5a(bc::settings{});
+    ////block block5a;
     ////block5a.set_header(header(block0.header()));
     ////block5a.header().set_nonce(99);
     ////block5a.set_transactions(
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////});
     ////const auto h5a = block5a.hash();
 
-    ////block block5b(bc::settings{});
+    ////block block5b;
     ////block5b.set_header(block0.header());
     ////block5b.header().set_nonce(222);
     ////block5b.set_transactions(
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(block_database__test)
     ////test::create(candidate_index);
     ////test::create(confirmed_index);
     ////test::create(tx_index);
-    ////block_database db(block_table, candidate_index, confirmed_index, tx_index, 1000, 50, bc::settings());
+    ////block_database db(block_table, candidate_index, confirmed_index, tx_index, 1000, 50);
     ////BOOST_REQUIRE(db.create());
 
     ////size_t height;

--- a/tools/initchain/initchain.cpp
+++ b/tools/initchain/initchain.cpp
@@ -62,8 +62,7 @@ int main(int argc, char** argv)
     const database::settings configuration;
     const bc::settings bitcoin_configuration(bc::config::settings::mainnet);
 
-    if (!data_base(configuration, bitcoin_configuration).create(
-        bitcoin_configuration.genesis_block))
+    if (!data_base(configuration).create(bitcoin_configuration.genesis_block))
     {
         std::cerr << BS_INITCHAIN_FAIL;
         return -1;


### PR DESCRIPTION
This reverts commit 848e17cb14a8383dc7b0cf2d2c893f2e7e956312.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013