### PR TITLE
Refactoring from v3 left an incorrect lock_upgrade

### DIFF
--- a/src/memory/accessor.cpp
+++ b/src/memory/accessor.cpp
@@ -57,6 +57,7 @@ void accessor::increment(size_t value)
 
 accessor::~accessor()
 {
+    mutex_.unlock_upgrade_and_lock_shared();
     mutex_.unlock_shared();
     // End Critical Section
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If assign() is never called for some reason, mutex_ will remain locked. Downgrading to lock_shared is atomic, and attempting to downgrade if already downgraded should have no effect. See:

https://www.boost.org/doc/libs/1_68_0/doc/html/thread/synchronization.html

"Lock ownership acquired through a call to lock_upgrade() must be released through a call to unlock_upgrade(). If the ownership type is changed through a call to one of the unlock_xxx_and_lock_yyy() functions, ownership must be released through a call to the unlock function corresponding to the new level of ownership."