### PR TITLE
Tests for block database v4

### DIFF
--- a/include/bitcoin/database/block_state.hpp
+++ b/include/bitcoin/database/block_state.hpp
@@ -44,7 +44,7 @@ enum block_state : uint8_t
 
 // validation states
 
-// This is not the same as !valid (could be pent).
+// This is not the same as !valid (could be spent).
 inline bool is_failed(uint8_t state)
 {
     return (state & block_state::failed) != 0;

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -67,7 +67,7 @@ static const auto state_offset = height_offset + height_size;
 static const auto checksum_offset = state_offset + state_size;
 static const auto transactions_offset = checksum_offset + checksum_size;
 
-// Total size of block header and metadta storage.
+// Total size of block header and metadata storage.
 static const auto block_size = header_size + median_time_past_size +
     height_size + state_size + checksum_size + tx_start_size + tx_count_size;
 

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -455,6 +455,8 @@ bool block_database::unindex(const hash_digest& hash, size_t height,
     if (!element)
         return false;
 
+    BITCOIN_ASSERT(hash == element.key());
+
     const auto original = index(element, false, candidate);
     pop_index(height, manager);
     return true;

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -439,7 +439,7 @@ bool block_database::index(const hash_digest& hash, size_t height,
     return true;
 }
 
-bool block_database::unindex(const hash_digest& hash, size_t height,
+bool block_database::unindex(const hash_digest& DEBUG_ONLY(hash), size_t height,
     bool candidate)
 {
     BITCOIN_ASSERT(height != max_uint32);

--- a/test/databases/block_database.cpp
+++ b/test/databases/block_database.cpp
@@ -47,202 +47,270 @@ struct block_database_directory_setup_fixture
     {
         test::clear_path(DIRECTORY);
     }
+
+    ~block_database_directory_setup_fixture()
+    {
+        test::clear_path(DIRECTORY);
+    }
 };
 
-BOOST_FIXTURE_TEST_SUITE(database_tests, block_database_directory_setup_fixture)
+BOOST_FIXTURE_TEST_SUITE(block_database_tests, block_database_directory_setup_fixture)
 
 BOOST_AUTO_TEST_CASE(block_database__test)
 {
     // TODO: replace.
-    ////auto block0 = block::genesis_mainnet();
-    ////block0.set_transactions(
-    ////{
-    ////    random_tx(0),
-    ////    random_tx(1)
-    ////});
-    ////const auto h0 = block0.hash();
+    static const auto settings = bc::settings(bc::config::settings::mainnet);
+    chain::block block0 = settings.genesis_block;
+    block0.set_transactions(
+    {
+       random_tx(0),
+       random_tx(1)
+    });
+    const auto h0 = block0.hash();
 
-    ////block block1;
-    ////block1.set_header(block0.header());
-    ////block1.header().set_nonce(4);
-    ////block1.set_transactions(
-    ////{
-    ////    random_tx(2),
-    ////    random_tx(3),
-    ////    random_tx(4),
-    ////    random_tx(5)
-    ////});
-    ////const auto h1 = block1.hash();
+    BOOST_REQUIRE_EQUAL(block0.transactions().size(), 2);
 
-    ////block block2;
-    ////block2.set_header(block0.header());
-    ////block2.header().set_nonce(110);
-    ////block2.set_transactions(
-    ////{
-    ////    random_tx(6),
-    ////    random_tx(7),
-    ////    random_tx(8),
-    ////    random_tx(9),
-    ////    random_tx(10)
-    ////});
-    ////const auto h2 = block2.hash();
+    auto header1 = block0.header();
+    header1.set_nonce(4);
+    block block1(header1, { random_tx(2), random_tx(3), random_tx(4), random_tx(5) });
+    const auto h1 = block1.hash();
+    BOOST_REQUIRE(h0 != h1);
 
-    ////block block3;
-    ////block3.set_header(block0.header());
-    ////block3.header().set_nonce(88);
-    ////block3.set_transactions(
-    ////{
-    ////    random_tx(11),
-    ////    random_tx(12),
-    ////    random_tx(13)
-    ////});
-    ////const auto h3 = block3.hash();
+    auto header2 = block0.header();
+    header2.set_nonce(110);
+    block block2(header2, { random_tx(6), random_tx(7), random_tx(8), random_tx(9), random_tx(10) });
+    const auto h2 = block2.hash();
+    BOOST_REQUIRE(h0 != h2);
 
-    ////block block4a;
-    ////block4a.set_header(block0.header());
-    ////block4a.header().set_nonce(63);
-    ////block4a.set_transactions(
-    ////{
-    ////    random_tx(14),
-    ////    random_tx(15),
-    ////    random_tx(16)
-    ////});
-    ////const auto h4a = block4a.hash();
+    auto header3 = block0.header();
+    header3.set_nonce(88);
+    block block3(header3, { random_tx(11), random_tx(12), random_tx(13) });
+    const auto h3 = block3.hash();
+    BOOST_REQUIRE(h0 != h3);
 
-    ////block block4b;
-    ////block4b.set_header(block0.header());
-    ////block4b.header().set_nonce(633);
-    ////block4b.set_transactions(
-    ////{
-    ////    random_tx(22),
-    ////    random_tx(23),
-    ////    random_tx(24)
-    ////});
-    ////const auto h4b = block4b.hash();
+    auto header4a = block0.header();
+    header4a.set_nonce(63);
+    block block4a(header4a, { random_tx(14), random_tx(15), random_tx(16) });
+    const auto h4a = block4a.hash();
+    BOOST_REQUIRE(h0 != h4a);
 
-    ////block block5a;
-    ////block5a.set_header(header(block0.header()));
-    ////block5a.header().set_nonce(99);
-    ////block5a.set_transactions(
-    ////{
-    ////    random_tx(17),
-    ////    random_tx(18),
-    ////    random_tx(19),
-    ////    random_tx(20),
-    ////    random_tx(21)
-    ////});
-    ////const auto h5a = block5a.hash();
+    auto header4b = block0.header();
+    header4b.set_nonce(633);
+    block block4b(header4b, { random_tx(22), random_tx(23), random_tx(24) });
+    const auto h4b = block4b.hash();
+    BOOST_REQUIRE(h0 != h4b);
 
-    ////block block5b;
-    ////block5b.set_header(block0.header());
-    ////block5b.header().set_nonce(222);
-    ////block5b.set_transactions(
-    ////{
-    ////    random_tx(25),
-    ////    random_tx(26),
-    ////    random_tx(27),
-    ////    random_tx(28),
-    ////    random_tx(29)
-    ////});
-    ////const auto h5b = block5b.hash();
+    auto header5a = block0.header();
+    header5a.set_nonce(99);
+    block block5a(header5a, { random_tx(17), random_tx(18), random_tx(19), random_tx(20), random_tx(21) });
+    const auto h5a = block5a.hash();
+    BOOST_REQUIRE(h0 != h5a);
 
-    ////const auto block_table = DIRECTORY "/block_table";
-    ////const auto candidate_index = DIRECTORY "/candidate_index";
-    ////const auto confirmed_index = DIRECTORY "/confirmed_index";
-    ////const auto tx_index = DIRECTORY "/tx_index";
+    auto header5b = block0.header();
+    header5b.set_nonce(222);
+    block block5b(header5b, { random_tx(25), random_tx(26), random_tx(27), random_tx(28), random_tx(29) });
+    const auto h5b = block5b.hash();
+    BOOST_REQUIRE(h0 != h5b);
 
-    ////test::create(block_table);
-    ////test::create(candidate_index);
-    ////test::create(confirmed_index);
-    ////test::create(tx_index);
-    ////block_database db(block_table, candidate_index, confirmed_index, tx_index, 1000, 50);
-    ////BOOST_REQUIRE(db.create());
+    const auto block_table = DIRECTORY "/block_table";
+    const auto candidate_index = DIRECTORY "/candidate_index";
+    const auto confirmed_index = DIRECTORY "/confirmed_index";
+    const auto tx_index = DIRECTORY "/tx_index";
 
-    ////size_t height;
-    ////BOOST_REQUIRE(!db.top(height, false));
+    test::create(block_table);
+    test::create(candidate_index);
+    test::create(confirmed_index);
+    test::create(tx_index);
+    block_database instance(block_table, candidate_index, confirmed_index, tx_index, 1000, 50);
+    BOOST_REQUIRE(instance.create());
 
-    ////db.push(block0, 0, 0);
-    ////db.push(block1, 1, 0);
-    ////db.push(block2, 2, 0);
-    ////db.push(block3, 3, 0);
-    ////BOOST_REQUIRE(db.top(height, false));
-    ////BOOST_REQUIRE_EQUAL(height, 3u);
+    size_t candidate_height = 0;
+    size_t confirmed_height = 0;
+    BOOST_REQUIRE(!instance.top(candidate_height, true));
+    BOOST_REQUIRE(!instance.top(confirmed_height, false));
 
-    ////// Fetch block 0 by hash.
-    ////const auto result0 = db.get(h0);
-    ////BOOST_REQUIRE(result0);
-    ////BOOST_REQUIRE(result0.hash() == h0);
+    BOOST_REQUIRE_EQUAL(block0.transactions().size(), 2);
 
-    ////auto it0 = result0.begin();
-    ////BOOST_REQUIRE(it0 != result0.end());
-    ////BOOST_REQUIRE_EQUAL(*it0++, 0u);
-    ////BOOST_REQUIRE_EQUAL(*it0++, 1u);
-    ////BOOST_REQUIRE(it0 == result0.end());
+    // Store blocks 0-4
+    instance.store(block0.header(), 0, 0);
+    instance.store(block1.header(), 1, 0);
+    instance.store(block2.header(), 2, 0);
+    instance.store(block3.header(), 3, 0);
 
-    ////// Fetch block 2 by hash.
-    ////const auto result2 = db.get(h2);
-    ////BOOST_REQUIRE(result2);
-    ////BOOST_REQUIRE(result2.hash() == h2);
+    BOOST_REQUIRE(!instance.top(candidate_height, true));
+    BOOST_REQUIRE(!instance.top(confirmed_height, false));
 
-    ////auto it2 = result2.begin();
-    ////BOOST_REQUIRE(it2 != result2.end());
-    ////BOOST_REQUIRE_EQUAL(*it2++, 6u);
-    ////BOOST_REQUIRE_EQUAL(*it2++, 7u);
-    ////BOOST_REQUIRE_EQUAL(*it2++, 8u);
-    ////BOOST_REQUIRE_EQUAL(*it2++, 9u);
-    ////BOOST_REQUIRE_EQUAL(*it2++, 10u);
-    ////BOOST_REQUIRE(it2 == result2.end());
+    BOOST_REQUIRE(instance.get(h0).hash() == h0);
+    BOOST_REQUIRE(!instance.get(0, true));
 
-    ////// Try a fork event.
-    ////db.push(block4a, 4, 0);
-    ////db.push(block5a, 5, 0);
+    // Add blocks 0-4 to candidate index
+    instance.index(h0, 0, true);
+    instance.index(h1, 1, true);
+    instance.index(h2, 2, true);
+    instance.index(h3, 3, true);
 
-    ////// Fetch blocks 4/5.
-    ////const auto result4a = db.get(4);
-    ////BOOST_REQUIRE(result4a);
-    ////BOOST_REQUIRE(result4a.hash() == h4a);
-    ////const auto result5a = db.get(5);
-    ////BOOST_REQUIRE(result5a);
-    ////BOOST_REQUIRE(result5a.hash() == h5a);
+    // Check heights for candidate and confirmed index
+    BOOST_REQUIRE(instance.top(candidate_height, true));
+    BOOST_REQUIRE(!instance.top(confirmed_height, false));
+    BOOST_REQUIRE_EQUAL(candidate_height, 3u);
 
-    ////// Unlink blocks 4a/5a.
-    ////BOOST_REQUIRE(db.top(height, false));
-    ////BOOST_REQUIRE_EQUAL(height, 5u);
-    ////db.unconfirm(h5a, 5, true);
-    ////db.unconfirm(h4a, 4, true);
-    ////BOOST_REQUIRE(db.top(height, false));
-    ////BOOST_REQUIRE_EQUAL(height, 3u);
+    // block 0 is in candidate index, with candidate state
+    BOOST_REQUIRE(instance.get(0, true));
+    BOOST_REQUIRE_EQUAL(instance.get(0, true).state(), block_state::candidate);
 
-    ////// Block 3 exists.
-    ////const auto result3 = db.get(3);
-    ////BOOST_REQUIRE(result3);
+    //validate block 1
+    BOOST_REQUIRE(instance.validate(h1, error::success));
+    BOOST_REQUIRE(instance.get(0, true).state() | block_state::valid);
 
-    ////// Blocks 4a/5a are missing (verify index guard).
-    ////const auto result4 = db.get(4);
-    ////BOOST_REQUIRE(!result4);
-    ////const auto result5 = db.get(5);
-    ////BOOST_REQUIRE(!result5);
+    // Add blocks 0-4 to confirmed index
+    instance.index(h0, 0, false);
+    instance.index(h1, 1, false);
+    instance.index(h2, 2, false);
+    instance.index(h3, 3, false);
 
-    ////// Add new blocks 4b/5b.
-    ////db.push(block4b, 4, 0);
-    ////db.push(block5b, 5, 0);
-    ////BOOST_REQUIRE(db.top(height, false));
-    ////BOOST_REQUIRE_EQUAL(height, 5u);
+    // block 0 stored, not updated, tx_count is not yet set
+    BOOST_REQUIRE_EQUAL(instance.get(h0).transaction_count(), 0);
 
-    ////// Fetch blocks 4b/5b.
-    ////const auto result4b = db.get(4);
-    ////BOOST_REQUIRE(result4b);
-    ////BOOST_REQUIRE(result4b.hash() == h4b);
-    ////const auto result5b = db.get(5);
-    ////BOOST_REQUIRE(result5b);
-    ////BOOST_REQUIRE(result5b.hash() == h5b);
+    // Update blocks
+    instance.update(block0);
+    instance.update(block1);
+    instance.update(block2);
+    instance.update(block3);
 
-    ////// Test also fetch by hash.
-    ////const auto result_h5b = db.get(h5b);
-    ////BOOST_REQUIRE(result_h5b);
-    ////BOOST_REQUIRE(result_h5b.hash() == h5b);
+    // Updated blocks set tx_count
+    BOOST_REQUIRE_EQUAL(instance.get(h0).transaction_count(), 2);
 
-    ////db.commit();
+    // block 0 is in candidate and confirmed index, with confirmed state
+    BOOST_REQUIRE(instance.get(0, true));
+    BOOST_REQUIRE_EQUAL(instance.get(0, true).state(), block_state::confirmed);
+    BOOST_REQUIRE(instance.get(0, false));
+    BOOST_REQUIRE_EQUAL(instance.get(0, false).state(), block_state::confirmed);
+
+    // block 1 is still valid
+    BOOST_REQUIRE(instance.get(0, true).state() | block_state::valid);
+
+    // Check heights for candidate and confirmed index
+    BOOST_REQUIRE(instance.top(candidate_height, true));
+    BOOST_REQUIRE(instance.top(confirmed_height, false));
+    BOOST_REQUIRE_EQUAL(candidate_height, 3u);
+    BOOST_REQUIRE_EQUAL(confirmed_height, 3u);
+
+    // unindex block 0 without clearing top should fail
+    BOOST_REQUIRE(!instance.unindex(h0, 2, true));
+
+    // TODO: unindex block 4a without indexing it should fail
+    // BOOST_REQUIRE(!instance.unindex(h4a, 3, true));
+
+    // unindex block 0 - 4 from candidate index
+    instance.unindex(h3, 3, true);
+    instance.unindex(h2, 2, true);
+    instance.unindex(h1, 1, true);
+    instance.unindex(h0, 0, true);
+
+    // block 0 is in only in confirmed index, with missing state
+    BOOST_REQUIRE(!instance.get(0, true));
+    BOOST_REQUIRE(instance.get(0, false));
+    BOOST_REQUIRE_EQUAL(instance.get(0, false).state(), block_state::missing);
+
+    // Check heights for candidate and confirmed index
+    BOOST_REQUIRE(!instance.top(candidate_height, true));
+    BOOST_REQUIRE(instance.top(confirmed_height, false));
+    // candidate height remains unchanged
+    BOOST_REQUIRE_EQUAL(candidate_height, 3u);
+    BOOST_REQUIRE_EQUAL(confirmed_height, 3u);
+
+    // Fetch block 0 by hash.
+    const auto result0 = instance.get(h0);
+
+    auto it0 = result0.begin();
+    BOOST_REQUIRE(it0 != result0.end());
+    BOOST_REQUIRE_EQUAL(*it0++, 0u);
+    BOOST_REQUIRE_EQUAL(*it0++, 1u);
+    BOOST_REQUIRE(it0 == result0.end());
+
+    // Fetch block 2 by hash.
+    const auto result2 = instance.get(h2);
+    BOOST_REQUIRE(result2);
+    BOOST_REQUIRE(result2.hash() == h2);
+
+    auto it2 = result2.begin();
+    BOOST_REQUIRE(it2 != result2.end());
+    BOOST_REQUIRE_EQUAL(*it2++, 6u);
+    BOOST_REQUIRE_EQUAL(*it2++, 7u);
+    BOOST_REQUIRE_EQUAL(*it2++, 8u);
+    BOOST_REQUIRE_EQUAL(*it2++, 9u);
+    BOOST_REQUIRE_EQUAL(*it2++, 10u);
+    BOOST_REQUIRE(it2 == result2.end());
+
+    // no metadata for missing blocks
+    instance.get_header_metadata(block4a.header());
+    BOOST_REQUIRE_EQUAL(block4b.header().metadata.candidate, block_state::missing);
+    BOOST_REQUIRE_EQUAL(block4b.header().metadata.confirmed, block_state::missing);
+
+    // Try a fork event.
+    instance.store(block4a.header(), 4, 0);
+    instance.store(block5a.header(), 5, 0);
+    instance.update(block4a);
+    instance.update(block5a);
+    instance.index(h4a, 4, false);
+    instance.index(h5a, 5, false);
+
+    // Fetch blocks 4/5.
+    const auto result4a = instance.get(h4a);
+    const auto result5a = instance.get(h5a);
+
+    // Unlink blocks 4a/5a.
+    BOOST_REQUIRE(instance.top(confirmed_height, false));
+    BOOST_REQUIRE_EQUAL(confirmed_height, 5u);
+    instance.unindex(h5a, 5, false);
+    instance.unindex(h4a, 4, false);
+    BOOST_REQUIRE(instance.top(confirmed_height, false));
+    BOOST_REQUIRE_EQUAL(confirmed_height, 3u);
+
+    // Block 3 exists.
+    const auto result3 = instance.get(3, false);
+    BOOST_REQUIRE(result3);
+
+    // Blocks 4a/5a are missing (verify index guard).
+    const auto result4 = instance.get(4, false);
+    BOOST_REQUIRE(!result4);
+    const auto result5 = instance.get(5, false);
+    BOOST_REQUIRE(!result5);
+
+    // Add new blocks 4b/5b.
+    instance.store(block4b.header(), 4, 0);
+    instance.store(block5b.header(), 5, 0);
+    instance.update(block4b);
+    instance.update(block5b);
+    instance.index(h4b, 4, false);
+    instance.index(h5b, 5, false);
+
+    BOOST_REQUIRE(instance.top(confirmed_height, false));
+    BOOST_REQUIRE_EQUAL(confirmed_height, 5u);
+
+    // Fetch blocks 4b/5b.
+    const auto result4b = instance.get(4, false);
+    BOOST_REQUIRE(result4b);
+    BOOST_REQUIRE(result4b.hash() == h4b);
+    const auto result5b = instance.get(5, false);
+    BOOST_REQUIRE(result5b);
+    BOOST_REQUIRE(result5b.hash() == h5b);
+
+    // Test also fetch by hash.
+    const auto result_h5b = instance.get(h5b);
+    BOOST_REQUIRE(result_h5b);
+    BOOST_REQUIRE(result_h5b.hash() == h5b);
+
+    // header metadata
+    instance.get_header_metadata(block4b.header());
+    BOOST_REQUIRE_EQUAL(block4b.header().metadata.error, error::success);
+    BOOST_REQUIRE(block4b.header().metadata.exists);
+    BOOST_REQUIRE(block4b.header().metadata.populated);
+    BOOST_REQUIRE(!block4b.header().metadata.validated);
+    BOOST_REQUIRE(!block4b.header().metadata.candidate);
+    BOOST_REQUIRE(block4b.header().metadata.confirmed);
+
+    instance.commit();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/databases/block_database.cpp
+++ b/test/databases/block_database.cpp
@@ -58,6 +58,7 @@ BOOST_FIXTURE_TEST_SUITE(block_database_tests, block_database_directory_setup_fi
 
 BOOST_AUTO_TEST_CASE(block_database__test)
 {
+    // TODO: replace.
     static const auto settings = bc::settings(bc::config::settings::mainnet);
     chain::block block0 = settings.genesis_block;
     block0.set_transactions(

--- a/test/databases/block_database.cpp
+++ b/test/databases/block_database.cpp
@@ -58,7 +58,6 @@ BOOST_FIXTURE_TEST_SUITE(block_database_tests, block_database_directory_setup_fi
 
 BOOST_AUTO_TEST_CASE(block_database__test)
 {
-    // TODO: replace.
     static const auto settings = bc::settings(bc::config::settings::mainnet);
     chain::block block0 = settings.genesis_block;
     block0.set_transactions(
@@ -165,11 +164,6 @@ BOOST_AUTO_TEST_CASE(block_database__test)
 
     // get 4a without indexing it should fail
     BOOST_REQUIRE(!instance.get(h4a));
-
-    // TODO: The test fails because the hash of element at height 3 is
-    // not compared to h4a in the unindex method    
-    // // unindex block 4a without indexing it should fail
-    // BOOST_REQUIRE(!instance.unindex(h4a, 3, true));
 
     // unindex block 0 - 4 from candidate index
     instance.unindex(h3, 3, true);


### PR DESCRIPTION
Rewrite tests for block_database

- Use same structure as that commented out
- Use store/index/update sequence to replace older block_database::push
- Use unindex to replace unconfirm
- Extend coverage to get_header_metadata

Also small spell fixes in src files