### PR TITLE
Proposed fix to slab_hash_table_header_size

### DIFF
--- a/include/bitcoin/database/primitives/slab_manager.hpp
+++ b/include/bitcoin/database/primitives/slab_manager.hpp
@@ -31,7 +31,7 @@ namespace database {
 BC_CONSTEXPR size_t minimum_slabs_size = sizeof(file_offset);
 BC_CONSTFUNC size_t slab_hash_table_header_size(size_t buckets)
 {
-    return sizeof(file_offset) + minimum_slabs_size * buckets;
+    return sizeof(array_index) + minimum_slabs_size * buckets;
 }
 
 /// The slab manager represents a growing collection of various sized


### PR DESCRIPTION
`slab_hash_table_header` is `hash_table_header<array_index, file_offset>`

Hash table header size based on:
 * ` [   size:IndexType   ]`
 * ` [ [      ...       ] ]`
 * ` [ [ item:ValueType ] ]`
 * ` [ [      ...       ] ]`

`IndexType` is of type `array_index` for slab hash table header.
Suggest updating `slab_hash_table_header_size(size_t buckets)` to reflect this.