### PR TITLE
Add tests for data_base, push/pop/candidate headers and blocks

### DIFF
--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -25,7 +25,6 @@
 #include <memory>
 #include <boost/filesystem.hpp>
 #include <bitcoin/system.hpp>
-#include <bitcoin/database/define.hpp>
 #include <bitcoin/database/databases/address_database.hpp>
 #include <bitcoin/database/databases/block_database.hpp>
 #include <bitcoin/database/databases/transaction_database.hpp>
@@ -112,9 +111,9 @@ public:
         system::block_const_ptr_list_ptr outgoing);
 
     // BLOCK ORGANIZER (confirm)
-    /// Confirm a block that is already in candidate index and parent
-    /// is already confirmed
-    code confirm(const hash_digest& block_hash, const size_t height);
+    /// Confirm candidate block with confirmed parent.
+    system::code confirm(const system::hash_digest& block_hash,
+        const size_t height);
     
     // TRANSACTION ORGANIZER (store)
     /// Store unconfirmed tx/payments that was verified with the given forks.

--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -113,7 +113,7 @@ public:
     // BLOCK ORGANIZER (confirm)
     /// Confirm candidate block with confirmed parent.
     system::code confirm(const system::hash_digest& block_hash,
-        const size_t height);
+        size_t height);
     
     // TRANSACTION ORGANIZER (store)
     /// Store unconfirmed tx/payments that was verified with the given forks.

--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -140,7 +140,7 @@ protected:
 
     bool push_all(system::block_const_ptr_list_const_ptr blocks,
         const system::config::checkpoint& fork_point);
-    bool pop_above(system::block_const_ptr_list_ptr headers,
+    bool pop_above(system::block_const_ptr_list_ptr blocks,
         const system::config::checkpoint& fork_point);
     system::code push_block(const system::chain::block& block, size_t height);
     system::code pop_block(system::chain::block& out_block, size_t height);

--- a/include/bitcoin/database/data_base.hpp
+++ b/include/bitcoin/database/data_base.hpp
@@ -111,6 +111,11 @@ public:
         system::block_const_ptr_list_const_ptr incoming,
         system::block_const_ptr_list_ptr outgoing);
 
+    // BLOCK ORGANIZER (confirm)
+    /// Confirm a block that is already in candidate index and parent
+    /// is already confirmed
+    code confirm(const hash_digest& block_hash, const size_t height);
+    
     // TRANSACTION ORGANIZER (store)
     /// Store unconfirmed tx/payments that was verified with the given forks.
     system::code store(const system::chain::transaction& tx, uint32_t forks);

--- a/include/bitcoin/database/verify.hpp
+++ b/include/bitcoin/database/verify.hpp
@@ -49,7 +49,7 @@ system::code verify_push(const block_database& blocks,
     const system::chain::block& block, size_t height);
 
 system::code verify_confirm(const block_database& blocks,
-    const system::hash_digest& block_hash,size_t height);
+    const system::hash_digest& block_hash, size_t height);
 
 system::code verify_update(const block_database& blocks,
     const system::chain::block& block, size_t height);

--- a/include/bitcoin/database/verify.hpp
+++ b/include/bitcoin/database/verify.hpp
@@ -48,6 +48,9 @@ system::code verify_push(const block_database& blocks,
 system::code verify_push(const block_database& blocks,
     const system::chain::block& block, size_t height);
 
+system::code verify_confirm(const block_database& blocks,
+    const system::hash_digest& block_hash,size_t height);
+
 system::code verify_update(const block_database& blocks,
     const system::chain::block& block, size_t height);
 

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -573,7 +573,7 @@ code data_base::pop_header(chain::header& out_header, size_t height)
     ///////////////////////////////////////////////////////////////////////////
     unique_lock lock(write_mutex_);
 
-    if ((verify_top(*blocks_, height, true)))
+    if ((ec = verify_top(*blocks_, height, true)))
         return ec;
 
     const auto result = blocks_->get(height, true);

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -325,7 +325,7 @@ code data_base::reorganize(const config::checkpoint& fork_point,
 }
 
 code data_base::confirm(const hash_digest& block_hash,
-                        const size_t height)
+    const size_t height)
 {   
     code ec;
 

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -339,11 +339,9 @@ code data_base::confirm(const hash_digest& block_hash,
         return error::operation_failed;
 
     // Mark block txs as confirmed.
-    transaction::list transactions;
-    for (const auto& offset: block)
-        transactions.push_back(transactions_->get(offset).transaction());
-
-    if (!transactions_->confirm(transactions, height, block.median_time_past()))
+    u_int32_t position = 0;
+    for (const auto& tx_offset: block)
+        if (!transactions_->confirm(tx_offset, height, block.median_time_past(), position++))
             return error::operation_failed;
     
     return error::success;

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -325,7 +325,7 @@ code data_base::reorganize(const config::checkpoint& fork_point,
 }
 
 code data_base::confirm(const hash_digest& block_hash,
-    const size_t height)
+    size_t height)
 {   
     code ec;
 
@@ -334,7 +334,7 @@ code data_base::confirm(const hash_digest& block_hash,
 
     const auto block = blocks().get(block_hash);
     
-    // index block as confirmed
+    // Index block as confirmed.
     if (!blocks_->index(block_hash, height, false))
         return error::operation_failed;
 

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -324,6 +324,21 @@ code data_base::reorganize(const config::checkpoint& fork_point,
     return result ? error::success : error::operation_failed;
 }
 
+code data_base::confirm(const hash_digest& block_hash,
+                        const size_t height)
+{   
+    code ec;
+
+    if ((ec = verify_confirm(*blocks_, block_hash, height)))
+        return error::operation_failed;
+    
+    // confirm
+    if (!blocks_->index(block_hash, height, false))
+        return error::operation_failed;
+    
+    return error::success;
+}
+
 // Add missing transactions for an existing block header.
 // This allows parallel write when write flushing is not enabled.
 code data_base::update(const chain::block& block, size_t height)

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -163,7 +163,7 @@ code verify_confirm(const block_database& blocks, const hash_digest& block_hash,
     if (get_next_block(blocks, false) != height)
         return error::store_block_invalid_height;
 
-    const auto block = blocks.get(block_hash, true);
+    const auto block = blocks.get(block_hash);
 
     if (!block)
         return error::not_found;

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -155,6 +155,28 @@ code verify_push(const block_database& blocks, const block& block,
     return error::success;
 }
 
+code verify_confirm(const block_database& blocks, const hash_digest& block_hash,
+                    size_t height)
+{
+#ifndef NDEBUG
+    // confirming to top
+    if (get_next_block(blocks, false) != height)
+        return error::store_block_invalid_height;
+
+    const auto block = blocks.get(block_hash, true);
+
+    if (!block)
+        return error::not_found;
+
+    // previous block in confirmed index is parent
+    if (get_previous_block(blocks, height, false) !=
+        block.header().previous_block_hash())
+        return error::store_block_missing_parent;
+#endif
+
+    return error::success;
+}
+    
 code verify_update(const block_database& blocks, const block& block,
     size_t height)
 {

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -156,7 +156,7 @@ code verify_push(const block_database& blocks, const block& block,
 }
 
 code verify_confirm(const block_database& blocks, const hash_digest& block_hash,
-                    size_t height)
+    size_t height)
 {
 #ifndef NDEBUG
     // confirming to top

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -1112,6 +1112,9 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
     test_heights(instance, 1u, 0u);
+    BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
+    BOOST_REQUIRE_EQUAL(block1.transactions().size(), 1);
+    BOOST_REQUIRE_EQUAL(instance.blocks().get(1, true).transaction_count(), 1);
 
     // setup ends
 
@@ -1120,7 +1123,12 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
     // test conditions
 
     test_heights(instance, 1u, 1u);
-    BOOST_REQUIRE(instance.blocks().get(1, false).hash() == block1.hash());
+    const auto& block_result = instance.blocks().get(1, false);
+    BOOST_REQUIRE(block_result.hash() == block1.hash());
+    test_block_exists(instance, 1, block1, settings.index_addresses, false);
+
+    for (const auto& offset: block_result)
+        BOOST_REQUIRE_EQUAL(instance.transactions().get(offset).candidate(), false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -704,10 +704,16 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above_missing_forkpoint_hash___fails)
    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});
 
    // setup ends
-   
-   BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(block1.hash(), 0)));
+
+   auto result = instance.pop_above(out_headers, config::checkpoint(block1.hash(), 0));
+#ifndef NDEBUG
+   BOOST_REQUIRE(!result);
+#else
+   BOOST_REQUIRE(result);
+#endif
 }
 
+#ifndef NDEBUG
 BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___fails)
 {
    create_directory(DIRECTORY);
@@ -730,9 +736,10 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___fails)
    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});
 
    // setup ends
-   
-   BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 10)));
+
+    BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 10)));
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(data_base__pop_above__pop_zero___success)
 {

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___fails)
 
 #ifndef NDEBUG
    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
-#elseif
+#else
    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::operation_failed);
 #endif
 }
@@ -541,9 +541,9 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__missing_parent___fails)
 
 #ifndef NDEBUG
    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
-#elseif
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::operation_failed);
-#endif
+#else
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+ #endif
 }
 
 BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -511,6 +511,32 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___fails)
    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
 }
 
+BOOST_AUTO_TEST_CASE(data_base__push_block__missing_parent___fails)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+
+   data_base_accessor instance(settings);
+
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+   block1.set_header(chain::header{});
+
+   // setup ends
+
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
+}
 
 BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)
 {

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -475,8 +475,42 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___fails)
     // setup ends
     
     BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::operation_failed);
+
+    // test conditions
+
     test_heights(instance, 0u, 0u);
 }
+
+BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___fails)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+
+   data_base_accessor instance(settings);
+
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   const auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+   test_heights(instance, 1u, 0u);
+
+   // setup ends
+
+   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
+}
+
 
 BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)
 {

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -508,7 +508,11 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___fails)
 
    // setup ends
 
+#ifndef NDEBUG
    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
+#elseif
+   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::operation_failed);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(data_base__push_block__missing_parent___fails)
@@ -535,7 +539,11 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__missing_parent___fails)
 
    // setup ends
 
+#ifndef NDEBUG
    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
+#elseif
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::operation_failed);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -1,21 +1,21 @@
 /**
-* Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
-*
-* This file is part of libbitcoin.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <boost/test/unit_test.hpp>
 
@@ -25,195 +25,192 @@
 #include <bitcoin/database.hpp>
 #include "utility/utility.hpp"
 
-using namespace bc;
-using namespace bc::chain;
+using namespace bc::system;
+using namespace bc::system::chain;
+using namespace bc::system::wallet;
 using namespace bc::database;
-using namespace bc::wallet;
 using namespace boost::system;
 using namespace boost::filesystem;
 
-static void
-test_block_exists(const data_base& interface, size_t height,
-                       const block& block, bool index_addresses, bool candidate)
+static void test_block_exists(const data_base& interface, size_t height,
+    const block& block, bool index_addresses, bool candidate)
 {
-   const auto& address_store = interface.addresses();
-   const auto block_hash = block.hash();
-   auto result = interface.blocks().get(height, candidate);
-   auto result_by_hash = interface.blocks().get(block_hash);
+    const auto& address_store = interface.addresses();
+    const auto block_hash = block.hash();
+    auto result = interface.blocks().get(height, candidate);
+    auto result_by_hash = interface.blocks().get(block_hash);
 
-   BOOST_REQUIRE(result);
-   BOOST_REQUIRE(result_by_hash);
-   BOOST_REQUIRE(result.hash() == block_hash);
-   BOOST_REQUIRE(result_by_hash.hash() == block_hash);
-   BOOST_REQUIRE_EQUAL(result.height(), height);
-   BOOST_REQUIRE_EQUAL(result_by_hash.height(), height);
-   BOOST_REQUIRE_EQUAL(result.transaction_count(), block.transactions().size());
-   BOOST_REQUIRE_EQUAL(result_by_hash.transaction_count(), block.transactions().size());
+    BOOST_REQUIRE(result);
+    BOOST_REQUIRE(result_by_hash);
+    BOOST_REQUIRE(result.hash() == block_hash);
+    BOOST_REQUIRE(result_by_hash.hash() == block_hash);
+    BOOST_REQUIRE_EQUAL(result.height(), height);
+    BOOST_REQUIRE_EQUAL(result_by_hash.height(), height);
+    BOOST_REQUIRE_EQUAL(result.transaction_count(), block.transactions().size());
+    BOOST_REQUIRE_EQUAL(result_by_hash.transaction_count(), block.transactions().size());
 
-   // TODO: test tx offsets (vs. tx hashes).
+    // TODO: test tx offsets (vs. tx hashes).
 
-   for (size_t i = 0; i < block.transactions().size(); ++i)
-   {
-       const auto& tx = block.transactions()[i];
-       const auto tx_hash = tx.hash();
-       ////BOOST_REQUIRE(result.transaction_hash(i) == tx_hash);
-       ////BOOST_REQUIRE(result_by_hash.transaction_hash(i) == tx_hash);
+    for (size_t i = 0; i < block.transactions().size(); ++i)
+    {
+        const auto& tx = block.transactions()[i];
+        const auto tx_hash = tx.hash();
+        ////BOOST_REQUIRE(result.transaction_hash(i) == tx_hash);
+        ////BOOST_REQUIRE(result_by_hash.transaction_hash(i) == tx_hash);
 
-       auto result_tx = interface.transactions().get(tx_hash);
-       BOOST_REQUIRE(result_tx);
-       BOOST_REQUIRE(result_by_hash);
-       BOOST_REQUIRE(result_tx.transaction().hash() == tx_hash);
-       BOOST_REQUIRE_EQUAL(result_tx.height(), height);
-       BOOST_REQUIRE_EQUAL(result_tx.position(), i);
+        auto result_tx = interface.transactions().get(tx_hash);
+        BOOST_REQUIRE(result_tx);
+        BOOST_REQUIRE(result_by_hash);
+        BOOST_REQUIRE(result_tx.transaction().hash() == tx_hash);
+        BOOST_REQUIRE_EQUAL(result_tx.height(), height);
+        BOOST_REQUIRE_EQUAL(result_tx.position(), i);
 
-       if (!tx.is_coinbase())
-       {
-           for (auto j = 0u; j < tx.inputs().size(); ++j)
-           {
-               const auto& input = tx.inputs()[j];
-               input_point spend{ tx_hash, j };
-               BOOST_REQUIRE_EQUAL(spend.index(), j);
+        if (!tx.is_coinbase())
+        {
+            for (auto j = 0u; j < tx.inputs().size(); ++j)
+            {
+                const auto& input = tx.inputs()[j];
+                input_point spend{ tx_hash, j };
+                BOOST_REQUIRE_EQUAL(spend.index(), j);
 
-               if (!index_addresses)
-                   continue;
+                if (!index_addresses)
+                    continue;
 
-               const auto addresses = input.addresses();
-               // const auto& prevout = input.previous_output();
-               ////const auto address = prevout.metadata.cache.addresses();
+                const auto addresses = input.addresses();
+                // const auto& prevout = input.previous_output();
+                ////const auto address = prevout.metadata.cache.addresses();
 
-               for (const payment_address& address: addresses)
-               {
-                   auto history = address_store.get(address.hash());
-                   auto found = false;
+                for (const payment_address& address: addresses)
+                {
+                    auto history = address_store.get(address.hash());
+                    auto found = false;
 
-                   for (const payment_record& row: history)
-                   {
-                       if (row.hash() == tx_hash && row.index() == j)
-                       {
-                           BOOST_REQUIRE_EQUAL(row.height(), height);
-                           found = true;
-                           break;
-                       }
-                   }
+                    for (const payment_record& row: history)
+                    {
+                        if (row.hash() == tx_hash && row.index() == j)
+                        {
+                            BOOST_REQUIRE_EQUAL(row.height(), height);
+                            found = true;
+                            break;
+                        }
+                    }
 
-                   BOOST_REQUIRE(found);
-               }
-           }
-       }
+                    BOOST_REQUIRE(found);
+                }
+            }
+        }
 
-       if (!index_addresses)
-           return;
+        if (!index_addresses)
+            return;
 
-       for (size_t j = 0; j < tx.outputs().size(); ++j)
-       {
-           const auto& output = tx.outputs()[j];
-           output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
-           const auto addresses = output.addresses();
+        for (size_t j = 0; j < tx.outputs().size(); ++j)
+        {
+            const auto& output = tx.outputs()[j];
+            output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
+            const auto addresses = output.addresses();
 
-           for (const payment_address& address: addresses)
-           {
-               auto history = address_store.get(address.hash());
-               auto found = false;
+            for (const payment_address& address: addresses)
+            {
+                auto history = address_store.get(address.hash());
+                auto found = false;
                
-               for (const payment_record& row: history)
-               {
-                   BOOST_REQUIRE(row.is_valid());
+                for (const payment_record& row: history)
+                {
+                    BOOST_REQUIRE(row.is_valid());
 
-                   if (row.hash() == tx_hash && row.index() == j)
-                   {
-                       BOOST_REQUIRE_EQUAL(row.height(), height);
-                       BOOST_REQUIRE_EQUAL(row.data(), output.value());
-                       found = true;
-                       break;
-                   }
-               }
+                    if (row.hash() == tx_hash && row.index() == j)
+                    {
+                        BOOST_REQUIRE_EQUAL(row.height(), height);
+                        BOOST_REQUIRE_EQUAL(row.data(), output.value());
+                        found = true;
+                        break;
+                    }
+                }
 
-               BOOST_REQUIRE(found);
-           }
-       }
-   }
+                BOOST_REQUIRE(found);
+            }
+        }
+    }
 }
 
-static void
-test_block_not_exists(const data_base& interface, const block& block0,
-                          bool index_addresses)
+static void test_block_not_exists(const data_base& interface, const block& block0,
+    bool index_addresses)
 {
-   const auto& address_store = interface.addresses();
+    const auto& address_store = interface.addresses();
 
-   // Popped blocks still exist in the block hash table, but not confirmed.
-   const auto block_hash = block0.hash();
-   const auto result = interface.blocks().get(block_hash);
-   BOOST_REQUIRE(!is_confirmed(result.state()));
+    // Popped blocks still exist in the block hash table, but not confirmed.
+    const auto block_hash = block0.hash();
+    const auto result = interface.blocks().get(block_hash);
+    BOOST_REQUIRE(!is_confirmed(result.state()));
 
-   for (size_t i = 0; i < block0.transactions().size(); ++i)
-   {
-       const auto& tx = block0.transactions()[i];
-       const auto tx_hash = tx.hash();
+    for (size_t i = 0; i < block0.transactions().size(); ++i)
+    {
+        const auto& tx = block0.transactions()[i];
+        const auto tx_hash = tx.hash();
 
-       if (!tx.is_coinbase())
-       {
-           for (size_t j = 0; j < tx.inputs().size(); ++j)
-           {
-               const auto& input = tx.inputs()[j];
-               // auto r0_spend = interface.spends().get(input.previous_output());
-               // BOOST_REQUIRE(!r0_spend.is_valid());
+        if (!tx.is_coinbase())
+        {
+            for (size_t j = 0; j < tx.inputs().size(); ++j)
+            {
+                const auto& input = tx.inputs()[j];
+                // auto r0_spend = interface.spends().get(input.previous_output());
+                // BOOST_REQUIRE(!r0_spend.is_valid());
 
-               if (!index_addresses)
-                   continue;
+                if (!index_addresses)
+                    continue;
 
-               const auto addresses = input.addresses();
-               ////const auto& prevout = input.previous_output();
-               ////const auto address = prevout.metadata.cache.addresses();
+                const auto addresses = input.addresses();
+                ////const auto& prevout = input.previous_output();
+                ////const auto address = prevout.metadata.cache.addresses();
 
-               for (const auto& address: addresses)
-               {
-                   auto history = address_store.get(address.hash());
-                   auto found = false;
+                for (const auto& address: addresses)
+                {
+                    auto history = address_store.get(address.hash());
+                    auto found = false;
 
-                   for (const payment_record& row: history)
-                   {
-                       if (row.hash() == tx_hash && row.index() == j)
-                       {
-                           found = true;
-                           break;
-                       }
-                   }
+                    for (const payment_record& row: history)
+                    {
+                        if (row.hash() == tx_hash && row.index() == j)
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
 
-                   BOOST_REQUIRE(!found);
-               }
-           }
-       }
+                    BOOST_REQUIRE(!found);
+                }
+            }
+        }
 
-       if (!index_addresses)
-           return;
+        if (!index_addresses)
+            return;
 
-       for (size_t j = 0; j < tx.outputs().size(); ++j)
-       {
-           const auto& output = tx.outputs()[j];
-           const auto addresses = output.addresses();
+        for (size_t j = 0; j < tx.outputs().size(); ++j)
+        {
+            const auto& output = tx.outputs()[j];
+            const auto addresses = output.addresses();
 
-           for (const auto& address: addresses)
-           {
-               auto history = address_store.get(address.hash());
-               auto found = false;
+            for (const auto& address: addresses)
+            {
+                auto history = address_store.get(address.hash());
+                auto found = false;
 
-               for (const auto& row: history)
-               {
-                   if (row.hash() == tx_hash && row.index() == j)
-                   {
-                       found = true;
-                       break;
-                   }
-               }
+                for (const auto& row: history)
+                {
+                    if (row.hash() == tx_hash && row.index() == j)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
 
-               BOOST_REQUIRE(!found);
-           }
-       }
-   }
+                BOOST_REQUIRE(!found);
+            }
+        }
+    }
 }
 
-static chain_state::data
-data_for_chain_state()
+static chain_state::data data_for_chain_state()
 {
     chain_state::data value;
     value.height = 1;
@@ -223,29 +220,26 @@ data_for_chain_state()
     return value;
 }
 
-static void
-set_state(block& block) {
+static void set_state(block& block)
+{
     auto state = std::make_shared<chain_state>(
-        chain_state{ data_for_chain_state(), {}, 0, 0, bc::settings() });
+        chain_state{ data_for_chain_state(), {}, 0, 0, bc::system::settings() });
     block.header().metadata.state = state;
 }
 
-static block
-read_block(const std::string hex)
+static block read_block(const std::string hex)
 {
-   data_chunk data;
-   BOOST_REQUIRE(decode_base16(data, hex));
-   block result;
-   BOOST_REQUIRE(result.from_data(data));
-   set_state(result);
-   return result;
+    data_chunk data;
+    BOOST_REQUIRE(decode_base16(data, hex));
+    block result;
+    BOOST_REQUIRE(result.from_data(data));
+    set_state(result);
+    return result;
 }
 
-static void
-store_block_transactions(data_base& instance, const block& block, size_t forks) {
-   for (const auto& tx: block.transactions()) {
-       instance.store(tx, forks);
-   }
+static void store_block_transactions(data_base& instance, const block& block, size_t forks) {
+    for (const auto& tx: block.transactions())
+        instance.store(tx, forks);
 }
 
 #define DIRECTORY "data_base"
@@ -268,7 +262,7 @@ BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
 
 #define TRANSACTION1 "0100000001537c9d05b5f7d67b09e5108e3bd5e466909cc9403ddd98bc42973f366fe729410600000000ffffffff0163000000000000001976a914fe06e7b4c88a719e92373de489c08244aee4520b88ac00000000"
 
-#define MAINNET_BLOCK1 \
+#define MAINNET_BLOCK1                                                  \
 "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982" \
 "051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff00" \
 "1d01e3629901010000000100000000000000000000000000000000000000000000000000000" \
@@ -276,7 +270,7 @@ BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
 "53519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a60" \
 "4f8141781e62294721166bf621e73a82cbf2342c858eeac00000000"
 
-#define MAINNET_BLOCK2 \
+#define MAINNET_BLOCK2                                                  \
 "010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5f" \
 "dcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff00" \
 "1d08d2bd6101010000000100000000000000000000000000000000000000000000000000000" \
@@ -284,7 +278,7 @@ BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
 "f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385" \
 "237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000"
 
-#define MAINNET_BLOCK3 \
+#define MAINNET_BLOCK3                                                  \
 "01000000bddd99ccfda39da1b108ce1a5d70038d0a967bacb68b6b63065f626a0000000044f" \
 "672226090d85db9a9f2fbfe5f0f9609b387af7be5b7fbb7a1767c831c9e995dbe6649ffff00" \
 "1d05e0ed6d01010000000100000000000000000000000000000000000000000000000000000" \
@@ -293,11 +287,11 @@ BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
 "6c5747f1db49e8cf90e75dc3e3550ae9b30086f3cd5aaac00000000"
 
 class data_base_accessor
- : public data_base
+  : public data_base
 {
 public:
     data_base_accessor(const bc::database::settings& settings)
-        : data_base(settings)
+      : data_base(settings)
     {
     }
 
@@ -337,7 +331,7 @@ public:
     }
 
     bool pop_above(header_const_ptr_list_ptr headers,
-                   const config::checkpoint& fork_point)
+        const config::checkpoint& fork_point)
     {
         return data_base::pop_above(headers, fork_point);
     }
@@ -350,8 +344,8 @@ public:
 
 };
 
-static void
-test_heights(const data_base& instance, size_t candidate_height_in, size_t confirmed_height_in)
+static void test_heights(const data_base& instance, size_t candidate_height_in,
+    size_t confirmed_height_in)
 {    
     size_t candidate_height = 0u;
     size_t confirmed_height = 0u;
@@ -364,82 +358,80 @@ test_heights(const data_base& instance, size_t candidate_height_in, size_t confi
 
 BOOST_AUTO_TEST_CASE(data_base__create__block_transactions_index_interaction__success)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
   
-   data_base instance(settings); 
+    data_base instance(settings); 
    
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
    
-   test_heights(instance, 0u, 0u);
+    test_heights(instance, 0u, 0u);
 
-   transaction tx1;
-   data_chunk wire_tx1;
-   BOOST_REQUIRE(decode_base16(wire_tx1, TRANSACTION1));
-   BOOST_REQUIRE(tx1.from_data(wire_tx1));
+    transaction tx1;
+    data_chunk wire_tx1;
+    BOOST_REQUIRE(decode_base16(wire_tx1, TRANSACTION1));
+    BOOST_REQUIRE(tx1.from_data(wire_tx1));
 
-   const auto hash1 = tx1.hash();
-   BOOST_REQUIRE(!instance.transactions().get(hash1));   
+    const auto hash1 = tx1.hash();
+    BOOST_REQUIRE(!instance.transactions().get(hash1));   
 }
 
 BOOST_AUTO_TEST_CASE(data_base__create__genesis_block_available__success)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
   
-   data_base instance(settings); 
+    data_base instance(settings); 
    
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;    
+    BOOST_REQUIRE(instance.create(genesis));
 
-   test_block_exists(instance, 0, genesis, settings.index_addresses, false);
+    test_block_exists(instance, 0, genesis, settings.index_addresses, false);
 }
 
 BOOST_AUTO_TEST_CASE(data_base__push__adds_to_blocks_and_transactions_validates_and_confirms__success)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
   
-   data_base instance(settings); 
+    data_base instance(settings); 
    
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
 
-   const auto block1 = read_block(MAINNET_BLOCK1);   
+    const auto block1 = read_block(MAINNET_BLOCK1);   
 
-   // setup ends
+    // setup ends
    
-   BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
 
-   // test conditions
+    // test conditions
    
-   test_block_exists(instance, 1, block1, settings.index_addresses, false);
-   test_heights(instance, 1u, 1u);
+    test_block_exists(instance, 1, block1, settings.index_addresses, false);
+    test_heights(instance, 1u, 1u);
 }
 
 // BLOCK ORGANIZER tests
@@ -448,7 +440,7 @@ BOOST_AUTO_TEST_CASE(data_base__push__adds_to_blocks_and_transactions_validates_
 BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___fails)
 {
     create_directory(DIRECTORY);
-    database::settings settings;
+    bc::database::settings settings;
     settings.directory = DIRECTORY;
     settings.index_addresses = false;
     settings.flush_writes = false;
@@ -459,9 +451,8 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___fails)
     
     data_base_accessor instance(settings); 
     
-    static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-    const chain::block genesis = bc_settings.genesis_block;
-    BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
     
     const auto block1 = read_block(MAINNET_BLOCK1);
     store_block_transactions(instance, block1, 1);
@@ -477,556 +468,8 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___fails)
 
 BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___fails)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-   test_heights(instance, 1u, 0u);
-
-   // setup ends
-
-#ifndef NDEBUG
-   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
-#else
-   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::operation_failed);
-#endif
-}
-
-BOOST_AUTO_TEST_CASE(data_base__push_header__missing_parent___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-   block1.set_header(chain::header{});
-
-   // setup ends
-
-#ifndef NDEBUG
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
-#else
-    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
- #endif
-}
-
-BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-   test_heights(instance, 1u, 0u);
-
-   // setup ends
-   
-   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
-   BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
-
-   // test conditions
-
-   test_heights(instance, 1u, 1u);
-   test_block_exists(instance, 1, block1, settings.index_addresses, false);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_header_not_top___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-
-   // setup ends
-
-   chain::header out_header;
-   BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::operation_failed);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_header__candidate___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-
-   // setup ends
-
-   chain::header out_header;
-   BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::success);
-
-   // test conditions
-
-   BOOST_REQUIRE(out_header.hash() == block1.header().hash());
-   test_heights(instance, 0u, 0u);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_block_not_top___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-
-   // setup ends
-
-   chain::block out_block;
-   BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::operation_failed);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_block__confirmed___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
-
-   // setup ends
-
-   chain::block out_block;
-   BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::success);
-
-   // test conditions
-
-   BOOST_REQUIRE(out_block.hash() == block1.hash());
-   test_block_not_exists(instance, block1, settings.index_addresses);
-   test_heights(instance, 1u, 0u);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__push_all_and_update__already_candidated___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-
-   block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
-   block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
-   block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-   const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{
-           block1_ptr, block2_ptr, block3_ptr });
-   store_block_transactions(instance, *block1_ptr, 1);
-   store_block_transactions(instance, *block2_ptr, 1);
-   store_block_transactions(instance, *block3_ptr, 1);
-
-   const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list{
-           std::make_shared<const message::header>(block1_ptr->header()),
-               std::make_shared<const message::header>(block2_ptr->header()),
-               std::make_shared<const message::header>(block3_ptr->header())
-               });
-      
-   BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
-   for(const auto block_ptr: *blocks_push_ptr) {
-       BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
-   }
-
-   test_heights(instance, 3u, 0u);
-
-   // setup ends
-   
-   BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
-   BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
-   BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
-   BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
-
-   // test conditions
-
-   test_heights(instance, 3u, 3u);
-   test_block_exists(instance, 1, *block1_ptr, settings.index_addresses, false);
-   test_block_exists(instance, 2, *block2_ptr, settings.index_addresses, false);
-   test_block_exists(instance, 3, *block3_ptr, settings.index_addresses, false);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_above_missing_forkpoint_hash___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});
-
-   // setup ends
-
-   auto result = instance.pop_above(out_headers, config::checkpoint(block1.hash(), 0));
-#ifndef NDEBUG
-   BOOST_REQUIRE(!result);
-#else
-   BOOST_REQUIRE(result);
-#endif
-}
-
-#ifndef NDEBUG
-BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});
-
-   // setup ends
-
-    BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 10)));
-}
-#endif
-
-BOOST_AUTO_TEST_CASE(data_base__pop_above__pop_zero___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});
-
-   // setup ends
-   
-   BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
-
-   // test conditions
-
-   test_heights(instance, 0u, 0u);   
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_above__candidated_not_confirmed___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-  
-   data_base_accessor instance(settings); 
-   
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-   
-   const auto block1 = read_block(MAINNET_BLOCK1);
-
-   block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
-   block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
-   block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-   const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{
-           block1_ptr, block2_ptr, block3_ptr });
-   store_block_transactions(instance, *block1_ptr, 1);
-   store_block_transactions(instance, *block2_ptr, 1);
-   store_block_transactions(instance, *block3_ptr, 1);
-
-   const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list{
-           std::make_shared<const message::header>(block1_ptr->header()),
-               std::make_shared<const message::header>(block2_ptr->header()),
-               std::make_shared<const message::header>(block3_ptr->header())
-               });
-      
-   BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
-   for(const auto block_ptr: *blocks_push_ptr) {
-       BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
-   }
-
-   test_heights(instance, 3u, 0u);
-
-   // setup ends
-   
-   auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list{});   
-   BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
-
-   // test conditions
-
-   BOOST_REQUIRE_EQUAL(out_headers->size(), 3);
-   test_heights(instance, 0u, 0u);
-   test_block_not_exists(instance, *block1_ptr, settings.index_addresses);
-   test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
-   test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
-}
-
-#ifndef NDEBUG
-BOOST_AUTO_TEST_CASE(data_base__pop_above2__wrong_forkpoint_height___fails)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list{});
-
-   // setup ends
-
-    BOOST_REQUIRE(!instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 10)));
-}
-#endif
-
-BOOST_AUTO_TEST_CASE(data_base__pop_above2__pop_zero___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list{});
-
-   // setup ends
-
-   BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
-
-   // test conditions
-
-   test_heights(instance, 0u, 0u);
-}
-
-BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
-{
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
-
-   data_base_accessor instance(settings);
-
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
-
-   const auto block1 = read_block(MAINNET_BLOCK1);
-
-   block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
-   block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
-   block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-   const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{
-           block1_ptr, block2_ptr, block3_ptr });
-   store_block_transactions(instance, *block1_ptr, 1);
-   store_block_transactions(instance, *block2_ptr, 1);
-   store_block_transactions(instance, *block3_ptr, 1);
-
-   const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list{
-           std::make_shared<const message::header>(block1_ptr->header()),
-               std::make_shared<const message::header>(block2_ptr->header()),
-               std::make_shared<const message::header>(block3_ptr->header())
-               });
-
-   BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
-   for(const auto block_ptr: *blocks_push_ptr) {
-       BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
-   }
-
-   BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
-   BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
-   BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
-   BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
-
-   test_heights(instance, 3u, 3u);
-
-   // setup ends
-
-   auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list{});
-   BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
-
-   // test conditions
-
-   BOOST_REQUIRE_EQUAL(out_blocks->size(), 3);
-   test_heights(instance, 3u, 0u);
-   test_block_not_exists(instance, *block1_ptr, settings.index_addresses);
-   test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
-   test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
-}
-
-/// Confirm
-
-BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___fails)
-{
     create_directory(DIRECTORY);
-    database::settings settings;
+    bc::database::settings settings;
     settings.directory = DIRECTORY;
     settings.index_addresses = false;
     settings.flush_writes = false;
@@ -1037,9 +480,547 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___fails)
 
     data_base_accessor instance(settings);
 
-    static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-    const chain::block genesis = bc_settings.genesis_block;
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+    test_heights(instance, 1u, 0u);
+
+    // setup ends
+
+#ifndef NDEBUG
+    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
+#else
+    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::operation_failed);
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push_header__missing_parent___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+    block1.set_header(chain::header{});
+
+    // setup ends
+
+#ifndef NDEBUG
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
+#else
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+    test_heights(instance, 1u, 0u);
+
+    // setup ends
+   
+    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
+
+    // test conditions
+
+    test_heights(instance, 1u, 1u);
+    test_block_exists(instance, 1, block1, settings.index_addresses, false);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_header_not_top___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+
+    // setup ends
+
+    chain::header out_header;
+    BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::operation_failed);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_header__candidate___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+
+    // setup ends
+
+    chain::header out_header;
+    BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::success);
+
+    // test conditions
+
+    BOOST_REQUIRE(out_header.hash() == block1.header().hash());
+    test_heights(instance, 0u, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_block_not_top___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+
+    // setup ends
+
+    chain::block out_block;
+    BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::operation_failed);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_block__confirmed___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
+
+    // setup ends
+
+    chain::block out_block;
+    BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::success);
+
+    // test conditions
+
+    BOOST_REQUIRE(out_block.hash() == block1.hash());
+    test_block_not_exists(instance, block1, settings.index_addresses);
+    test_heights(instance, 1u, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push_all_and_update__already_candidated___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+    
+    data_base_accessor instance(settings); 
+    
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
     BOOST_REQUIRE(instance.create(genesis));
+    
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    
+    block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
+    block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
+    block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
+    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{block1_ptr, block2_ptr, block3_ptr });
+    
+    store_block_transactions(instance, *block1_ptr, 1);
+    store_block_transactions(instance, *block2_ptr, 1);
+    store_block_transactions(instance, *block3_ptr, 1);
+
+    const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1_ptr->header()),
+        std::make_shared<const message::header>(block2_ptr->header()),
+        std::make_shared<const message::header>(block3_ptr->header())
+    });
+    
+    BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
+
+    for (const auto block_ptr: *blocks_push_ptr)
+        BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
+    
+    test_heights(instance, 3u, 0u);
+    
+    // setup ends
+    
+    BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
+    BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
+    BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
+    
+    // test conditions
+    
+    test_heights(instance, 3u, 3u);
+    test_block_exists(instance, 1, *block1_ptr, settings.index_addresses, false);
+    test_block_exists(instance, 2, *block2_ptr, settings.index_addresses, false);
+    test_block_exists(instance, 3, *block3_ptr, settings.index_addresses, false);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_above_missing_forkpoint_hash___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+
+    // setup ends
+
+    const auto result = instance.pop_above(out_headers, config::checkpoint(block1.hash(), 0));
+#ifndef NDEBUG
+    BOOST_REQUIRE(!result);
+#else
+    BOOST_REQUIRE(result);
+#endif
+}
+
+#ifndef NDEBUG
+BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+
+    // setup ends
+
+    BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 10)));
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(data_base__pop_above__pop_zero___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+
+    // setup ends
+   
+    BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
+
+    // test conditions
+
+    test_heights(instance, 0u, 0u);   
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_above__candidated_not_confirmed___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+  
+    data_base_accessor instance(settings); 
+   
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+   
+    const auto block1 = read_block(MAINNET_BLOCK1);
+
+    block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
+    block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
+    block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
+    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{block1_ptr, block2_ptr, block3_ptr });
+    store_block_transactions(instance, *block1_ptr, 1);
+    store_block_transactions(instance, *block2_ptr, 1);
+    store_block_transactions(instance, *block3_ptr, 1);
+
+    const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1_ptr->header()),
+        std::make_shared<const message::header>(block2_ptr->header()),
+        std::make_shared<const message::header>(block3_ptr->header())
+    });
+      
+    BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
+    for (const auto block_ptr: *blocks_push_ptr)
+        BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
+
+    test_heights(instance, 3u, 0u);
+
+    // setup ends
+   
+    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());   
+    BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
+
+    // test conditions
+
+    BOOST_REQUIRE_EQUAL(out_headers->size(), 3);
+    test_heights(instance, 0u, 0u);
+    test_block_not_exists(instance, *block1_ptr, settings.index_addresses);
+    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
+    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
+}
+
+#ifndef NDEBUG
+BOOST_AUTO_TEST_CASE(data_base__pop_above2__wrong_forkpoint_height___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+
+    // setup ends
+
+    BOOST_REQUIRE(!instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 10)));
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(data_base__pop_above2__pop_zero___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+
+    // setup ends
+
+    BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
+
+    // test conditions
+
+    test_heights(instance, 0u, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    const chain::block& genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+
+    block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
+    block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
+    block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
+    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{block1_ptr, block2_ptr, block3_ptr });
+    store_block_transactions(instance, *block1_ptr, 1);
+    store_block_transactions(instance, *block2_ptr, 1);
+    store_block_transactions(instance, *block3_ptr, 1);
+
+    const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list
+    {
+        std::make_shared<const message::header>(block1_ptr->header()),
+        std::make_shared<const message::header>(block2_ptr->header()),
+        std::make_shared<const message::header>(block3_ptr->header())
+    });
+
+    BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
+    for (const auto block_ptr: *blocks_push_ptr) 
+        BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
+
+    BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
+    BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
+    BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
+
+    test_heights(instance, 3u, 3u);
+
+    // setup ends
+
+    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+    BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
+
+    // test conditions
+
+    BOOST_REQUIRE_EQUAL(out_blocks->size(), 3);
+    test_heights(instance, 3u, 0u);
+    test_block_not_exists(instance, *block1_ptr, settings.index_addresses);
+    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
+    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
+}
+
+/// Confirm
+
+BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___fails)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
 
     const auto block1 = read_block(MAINNET_BLOCK1);
     store_block_transactions(instance, block1, 1);
@@ -1055,94 +1036,91 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___fails)
 
 BOOST_AUTO_TEST_CASE(data_base__confirm__incorrect_height___fails)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
 
-   data_base_accessor instance(settings);
+    data_base_accessor instance(settings);
 
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
 
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
 
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-   test_heights(instance, 1u, 0u);
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+    test_heights(instance, 1u, 0u);
 
-   // setup ends
+    // setup ends
 
-   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 2), error::operation_failed);
+    BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 2), error::operation_failed);
 }
 
 BOOST_AUTO_TEST_CASE(data_base__confirm__missing_parent___fails)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
 
-   data_base_accessor instance(settings);
+    data_base_accessor instance(settings);
 
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
 
-   auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
-   block1.set_header(chain::header{});
+    auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+    block1.set_header(chain::header{});
 
-   // setup ends
+    // setup ends
 
-   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
+    BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
 }
 
 BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
 {
-   create_directory(DIRECTORY);
-   database::settings settings;
-   settings.directory = DIRECTORY;
-   settings.index_addresses = false;
-   settings.flush_writes = false;
-   settings.file_growth_rate = 42;
-   settings.block_table_buckets = 42;
-   settings.transaction_table_buckets = 42;
-   settings.address_table_buckets = 42;
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
 
-   data_base_accessor instance(settings);
+    data_base_accessor instance(settings);
 
-   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
-   const chain::block genesis = bc_settings.genesis_block;
-   BOOST_REQUIRE(instance.create(genesis));
+    static const auto bc_settings = bc::system::settings(bc::system::config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
 
-   const auto block1 = read_block(MAINNET_BLOCK1);
-   store_block_transactions(instance, block1, 1);
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
 
-   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
-   test_heights(instance, 1u, 0u);
+    BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+    test_heights(instance, 1u, 0u);
 
-   // setup ends
+    // setup ends
 
-   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::success);
+    BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::success);
 
-   // test conditions
+    // test conditions
 
-   test_heights(instance, 1u, 1u);
-   BOOST_REQUIRE(instance.blocks().get(1, false).hash() == block1.hash());
+    test_heights(instance, 1u, 1u);
+    BOOST_REQUIRE(instance.blocks().get(1, false).hash() == block1.hash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -297,17 +297,20 @@ public:
     {
     }
 
-    bool push_all(block_const_ptr_list_const_ptr blocks, const config::checkpoint& fork_point)
+    bool push_all(block_const_ptr_list_const_ptr blocks,
+        const config::checkpoint& fork_point)
     {
         return data_base::push_all(blocks, fork_point);
     }
 
-    bool push_all(header_const_ptr_list_const_ptr headers, const config::checkpoint& fork_point)
+    bool push_all(header_const_ptr_list_const_ptr headers,
+        const config::checkpoint& fork_point)
     {
         return data_base::push_all(headers, fork_point);
     }
     
-    code push_header(const header& header, size_t height, uint32_t median_time_past)
+    code push_header(const header& header, size_t height,
+        uint32_t median_time_past)
     {
         return data_base::push_header(header, height, median_time_past);
     }
@@ -345,8 +348,8 @@ public:
     }
 };
 
-static void test_heights(const data_base& instance, size_t check_candidate_height,
-    size_t check_confirmed_height)
+static void test_heights(const data_base& instance,
+    size_t check_candidate_height, size_t check_confirmed_height)
 {    
     size_t candidate_height = 0u;
     size_t confirmed_height = 0u;
@@ -708,7 +711,7 @@ BOOST_AUTO_TEST_CASE(data_base__push_all_and_update__already_candidated___succes
     block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
     block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
     block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{block1_ptr, block2_ptr, block3_ptr });
+    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1_ptr, block2_ptr, block3_ptr });
     
     store_block_transactions(instance, *block1_ptr, 1);
     store_block_transactions(instance, *block2_ptr, 1);
@@ -761,7 +764,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above_missing_forkpoint_hash___failure)
     BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
    
     const auto block1 = read_block(MAINNET_BLOCK1);
-    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+    const auto out_headers = std::make_shared<header_const_ptr_list>();
 
     // setup ends
 
@@ -793,7 +796,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___failure)
     BOOST_REQUIRE(instance.create(genesis));
    
     const auto block1 = read_block(MAINNET_BLOCK1);
-    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+    const auto out_headers = std::make_shared<header_const_ptr_list>();
 
     // setup ends
 
@@ -820,7 +823,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__pop_zero___success)
     BOOST_REQUIRE(instance.create(genesis));
    
     const auto block1 = read_block(MAINNET_BLOCK1);
-    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());
+    const auto out_headers = std::make_shared<header_const_ptr_list>();
 
     // setup ends
    
@@ -874,7 +877,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__candidated_not_confirmed___success)
 
     // setup ends
    
-    auto out_headers = std::make_shared<header_const_ptr_list>(header_const_ptr_list());   
+    const auto out_headers = std::make_shared<header_const_ptr_list>();
     BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
 
     // test conditions
@@ -906,7 +909,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__wrong_forkpoint_height___failure)
     BOOST_REQUIRE(instance.create(genesis));
 
     const auto block1 = read_block(MAINNET_BLOCK1);
-    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+    const auto out_blocks = std::make_shared<block_const_ptr_list>();
 
     // setup ends
 
@@ -933,7 +936,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__pop_zero___success)
     BOOST_REQUIRE(instance.create(genesis));
 
     const auto block1 = read_block(MAINNET_BLOCK1);
-    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+    const auto out_blocks = std::make_shared<block_const_ptr_list>();
 
     // setup ends
 
@@ -967,7 +970,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
     block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
     block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
     block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{block1_ptr, block2_ptr, block3_ptr });
+    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block1_ptr, block2_ptr, block3_ptr });
     store_block_transactions(instance, *block1_ptr, 1);
     store_block_transactions(instance, *block2_ptr, 1);
     store_block_transactions(instance, *block3_ptr, 1);
@@ -992,7 +995,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
 
     // setup ends
 
-    auto out_blocks = std::make_shared<block_const_ptr_list>(block_const_ptr_list());
+    const auto out_blocks = std::make_shared<block_const_ptr_list>();
     BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
 
     // test conditions

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -1021,4 +1021,128 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
 }
 
+/// Confirm
+
+BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___fails)
+{
+    create_directory(DIRECTORY);
+    database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings);
+
+    static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+    const chain::block genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+
+    // setup ends
+
+    BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
+
+    // test conditions
+
+    test_heights(instance, 0u, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__confirm__incorrect_height___fails)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+
+   data_base_accessor instance(settings);
+
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   const auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+   test_heights(instance, 1u, 0u);
+
+   // setup ends
+
+   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 2), error::operation_failed);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__confirm__missing_parent___fails)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+
+   data_base_accessor instance(settings);
+
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+   block1.set_header(chain::header{});
+
+   // setup ends
+
+   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+
+   data_base_accessor instance(settings);
+
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   const auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+   test_heights(instance, 1u, 0u);
+
+   // setup ends
+
+   BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::success);
+
+   // test conditions
+
+   test_heights(instance, 1u, 1u);
+   BOOST_REQUIRE(instance.blocks().get(1, false).hash() == block1.hash());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -1128,7 +1128,7 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
     test_block_exists(instance, 1, block1, settings.index_addresses, false);
 
     for (const auto& offset: block_result)
-        BOOST_REQUIRE_EQUAL(instance.transactions().get(offset).candidate(), false);
+        BOOST_REQUIRE(!instance.transactions().get(offset).candidate());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -1,401 +1,665 @@
-/////**
-//// * Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
-//// *
-//// * This file is part of libbitcoin.
-//// *
-//// * This program is free software: you can redistribute it and/or modify
-//// * it under the terms of the GNU Affero General Public License as published by
-//// * the Free Software Foundation, either version 3 of the License, or
-//// * (at your option) any later version.
-//// *
-//// * This program is distributed in the hope that it will be useful,
-//// * but WITHOUT ANY WARRANTY; without even the implied warranty of
-//// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//// * GNU Affero General Public License for more details.
-//// *
-//// * You should have received a copy of the GNU Affero General Public License
-//// * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//// */
-////#include <boost/test/unit_test.hpp>
-////
-////#include <future>
-////#include <memory>
-////#include <boost/filesystem.hpp>
-////#include <bitcoin/database.hpp>
-////#include "utility/utility.hpp"
-////
-////using namespace bc;
-////using namespace bc::chain;
-////using namespace bc::database;
-////using namespace bc::wallet;
-////using namespace boost::system;
-////using namespace boost::filesystem;
-////
-////void test_block_exists(const data_base& interface, size_t height,
-////    const block& block, bool index_addresses)
-////{
-////    const auto& address_store = interface.addresses();
-////    const auto block_hash = block.hash();
-////    auto result = interface.blocks().get(height);
-////    auto result_by_hash = interface.blocks().get(block_hash);
-////
-////    BOOST_REQUIRE(result);
-////    BOOST_REQUIRE(result_by_hash);
-////    BOOST_REQUIRE(result.hash() == block_hash);
-////    BOOST_REQUIRE(result_by_hash.hash() == block_hash);
-////    BOOST_REQUIRE_EQUAL(result.height(), height);
-////    BOOST_REQUIRE_EQUAL(result_by_hash.height(), height);
-////    BOOST_REQUIRE_EQUAL(result.transaction_count(), block.transactions().size());
-////    BOOST_REQUIRE_EQUAL(result_by_hash.transaction_count(), block.transactions().size());
-////
-////    // TODO: test tx offsets (vs. tx hashes).
-////
-////    for (size_t i = 0; i < block.transactions().size(); ++i)
-////    {
-////        const auto& tx = block.transactions()[i];
-////        const auto tx_hash = tx.hash();
-////        ////BOOST_REQUIRE(result.transaction_hash(i) == tx_hash);
-////        ////BOOST_REQUIRE(result_by_hash.transaction_hash(i) == tx_hash);
-////
-////        auto result_tx = interface.transactions().get(tx_hash);
-////        BOOST_REQUIRE(result_tx);
-////        BOOST_REQUIRE(result_by_hash);
-////        BOOST_REQUIRE(result_tx.transaction().hash() == tx_hash);
-////        BOOST_REQUIRE_EQUAL(result_tx.height(), height);
-////        BOOST_REQUIRE_EQUAL(result_tx.position(), i);
-////
-////        if (!tx.is_coinbase())
-////        {
-////            for (auto j = 0u; j < tx.inputs().size(); ++j)
-////            {
-////                const auto& input = tx.inputs()[j];
-////                input_point spend{ tx_hash, j };
-////                BOOST_REQUIRE_EQUAL(spend.index(), j);
-////
-////                if (!index_addresses)
-////                    continue;
-////
-////                const auto addresses = input.addresses();
-////                const auto& prevout = input.previous_output();
-////                ////const auto address = prevout.metadata.cache.addresses();
-////
-////                for (const auto& address: addresses)
-////                {
-////                    auto history = address_store.get(address.hash(), 0, 0);
-////                    auto found = false;
-////
-////                    for (const auto& row: history)
-////                    {
-////                        if (row.point() == spend)
-////                        {
-////                            BOOST_REQUIRE_EQUAL(row.height(), height);
-////                            found = true;
-////                            break;
-////                        }
-////                    }
-////
-////                    BOOST_REQUIRE(found);
-////                }
-////            }
-////        }
-////
-////        if (!index_addresses)
-////            return;
-////
-////        for (size_t j = 0; j < tx.outputs().size(); ++j)
-////        {
-////            const auto& output = tx.outputs()[j];
-////            output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
-////            const auto addresses = output.addresses();
-////
-////            for (const auto& address: addresses)
-////            {
-////                auto history = address_store.get(address.hash(), 0, 0);
-////                auto found = false;
-////
-////                for (const auto& row: history)
-////                {
-////                    BOOST_REQUIRE(row.is_valid());
-////
-////                    if (row.point() == outpoint)
-////                    {
-////                        BOOST_REQUIRE_EQUAL(row.height(), height);
-////                        BOOST_REQUIRE_EQUAL(row.data(), output.value());
-////                        found = true;
-////                        break;
-////                    }
-////                }
-////
-////                BOOST_REQUIRE(found);
-////            }
-////        }
-////    }
-////}
-////
-////void test_block_not_exists(const data_base& interface, const block& block0,
-////    bool index_addresses)
-////{
-////    const auto& address_store = interface.history();
-////
-////    // Popped blocks still exist in the block hash table, but not confirmed.
-////    const auto block_hash = block0.hash();
-////    const auto result = interface.blocks().get(block_hash);
-////    BOOST_REQUIRE(!is_confirmed(result.state()));
-////
-////    for (size_t i = 0; i < block0.transactions().size(); ++i)
-////    {
-////        const auto& tx = block0.transactions()[i];
-////        const auto tx_hash = tx.hash();
-////
-////        if (!tx.is_coinbase())
-////        {
-////            for (size_t j = 0; j < tx.inputs().size(); ++j)
-////            {
-////                const auto& input = tx.inputs()[j];
-////                input_point spend{ tx_hash, static_cast<uint32_t>(j) };
-////                auto r0_spend = interface.spends().get(input.previous_output());
-////                BOOST_REQUIRE(!r0_spend.is_valid());
-////
-////                if (!index_addresses)
-////                    continue;
-////
-////                const auto addresses = input.addresses();
-////                ////const auto& prevout = input.previous_output();
-////                ////const auto address = prevout.metadata.cache.addresses();
-////
-////                for (const auto& address: addresses)
-////                {
-////                    auto history = address_store.get(address.hash(), 0, 0);
-////                    auto found = false;
-////
-////                    for (const auto& row: history)
-////                    {
-////                        if (row.point() == spend)
-////                        {
-////                            found = true;
-////                            break;
-////                        }
-////                    }
-////
-////                    BOOST_REQUIRE(!found);
-////                }
-////            }
-////        }
-////
-////        if (!index_addresses)
-////            return;
-////
-////        for (size_t j = 0; j < tx.outputs().size(); ++j)
-////        {
-////            const auto& output = tx.outputs()[j];
-////            output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
-////            const auto addresses = output.addresses();
-////
-////            for (const auto& address: addresses)
-////            {
-////                auto history = address_store.get(address.hash(), 0, 0);
-////                auto found = false;
-////
-////                for (const auto& row: history)
-////                {
-////                    if (row.point() == outpoint)
-////                    {
-////                        found = true;
-////                        break;
-////                    }
-////                }
-////
-////                BOOST_REQUIRE(!found);
-////            }
-////        }
-////    }
-////}
-////
-////block read_block(const std::string hex)
-////{
-////    data_chunk data;
-////    BOOST_REQUIRE(decode_base16(data, hex));
-////    block result;
-////    BOOST_REQUIRE(result.from_data(data));
-////    return result;
-////}
-////
-////#define DIRECTORY "data_base"
-////
-////struct data_base_setup_fixture
-////{
-////    data_base_setup_fixture()
-////    {
-////        test::clear_path(DIRECTORY);
-////    }
-////};
-////
-////
-////BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
-////
-////#define MAINNET_BLOCK1 \
-////"010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982" \
-////"051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff00" \
-////"1d01e3629901010000000100000000000000000000000000000000000000000000000000000" \
-////"00000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e8" \
-////"53519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a60" \
-////"4f8141781e62294721166bf621e73a82cbf2342c858eeac00000000"
-////
-////#define MAINNET_BLOCK2 \
-////"010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5f" \
-////"dcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff00" \
-////"1d08d2bd6101010000000100000000000000000000000000000000000000000000000000000" \
-////"00000000000ffffffff0704ffff001d010bffffffff0100f2052a010000004341047211a824" \
-////"f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385" \
-////"237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000"
-////
-////#define MAINNET_BLOCK3 \
-////"01000000bddd99ccfda39da1b108ce1a5d70038d0a967bacb68b6b63065f626a0000000044f" \
-////"672226090d85db9a9f2fbfe5f0f9609b387af7be5b7fbb7a1767c831c9e995dbe6649ffff00" \
-////"1d05e0ed6d01010000000100000000000000000000000000000000000000000000000000000" \
-////"00000000000ffffffff0704ffff001d010effffffff0100f2052a0100000043410494b9d3e7" \
-////"6c5b1629ecf97fff95d7a4bbdac87cc26099ada28066c6ff1eb9191223cd897194a08d0c272" \
-////"6c5747f1db49e8cf90e75dc3e3550ae9b30086f3cd5aaac00000000"
-////
-////class data_base_accessor
-////  : public data_base
-////{
-////public:
-////    data_base_accessor(const settings& settings)
-////      : data_base(settings)
-////    {
-////    }
-////
-////    void pop_above(block_const_ptr_list_ptr blocks,
-////        const config::checkpoint& fork_point, dispatcher& dispatch,
-////        result_handler handler)
-////    {
-////        data_base::pop_above(blocks, fork_point, dispatch, handler);
-////    }
-////
-////    void push_next(block_const_ptr_list_const_ptr blocks, size_t index,
-////        size_t height, dispatcher& dispatch, result_handler handler)
-////    {
-////        data_base::push_next(error::success, blocks, index, height,
-////            dispatch, handler);
-////    }
-////};
-////
-////static code pop_above_result(data_base_accessor& instance,
-////    block_const_ptr_list_ptr out_blocks, const config::checkpoint& fork_point,
-////    dispatcher& dispatch)
-////{
-////    std::promise<code> promise;
-////    const auto handler = [&promise](code ec)
-////    {
-////        promise.set_value(ec);
-////    };
-////    instance.pop_above(out_blocks, fork_point, dispatch, handler);
-////    return promise.get_future().get();
-////}
-////
-////static code push_all_result(data_base_accessor& instance,
-////    block_const_ptr_list_const_ptr in_blocks, size_t index, size_t height,
-////    dispatcher& dispatch)
-////{
-////    std::promise<code> promise;
-////    const auto handler = [&promise](code ec)
-////    {
-////        promise.set_value(ec);
-////    };
-////    instance.push_next(in_blocks, index, height, dispatch, handler);
-////    return promise.get_future().get();
-////}
-////
-////BOOST_AUTO_TEST_CASE(data_base__pushpop__test)
-////{
-////    std::cout << "begin data_base push/pop test" << std::endl;
-////
-////    create_directory(DIRECTORY);
-////    database::settings settings;
-////    settings.directory = DIRECTORY;
-////    settings.index_addresses = true;
-////    settings.flush_writes = false;
-////    settings.file_growth_rate = 42;
-////    settings.block_table_buckets = 42;
-////    settings.transaction_table_buckets = 42;
-////    settings.address_table_buckets = 42;
-////
-////    size_t height;
-////    threadpool pool(1);
-////    dispatcher dispatch(pool, "test");
-////    data_base_accessor instance(settings);
-////    const auto block0 = block::genesis_mainnet();
-////    BOOST_REQUIRE(instance.create(block0));
-////    test_block_exists(instance, 0, block0, settings.index_addresses);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 0);
-////
-////    // This tests a missing parent, not a database failure.
-////    // A database failure would prevent subsequent read/write operations.
-////    std::cout << "push block #1 (store_block_missing_parent)" << std::endl;
-////    auto invalid_block1 = read_block(MAINNET_BLOCK1);
-////    invalid_block1.set_header(chain::header{});
-////    BOOST_REQUIRE_EQUAL(instance.push(invalid_block1, 1), error::store_block_missing_parent);
-////
-////    std::cout << "push block #1" << std::endl;
-////    const auto block1 = read_block(MAINNET_BLOCK1);
-////    test_block_not_exists(instance, block1, settings.index_addresses);
-////    BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
-////    test_block_exists(instance, 0, block0, settings.index_addresses);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 1u);
-////    test_block_exists(instance, 1, block1, settings.index_addresses);
-////
-////    std::cout << "push_all blocks #2 & #3" << std::endl;
-////    const auto block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
-////    const auto block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
-////    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block2_ptr, block3_ptr });
-////    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
-////    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
-////    BOOST_REQUIRE_EQUAL(push_all_result(instance, blocks_push_ptr, 0, 2, dispatch), error::success);
-////    test_block_exists(instance, 1, block1, settings.index_addresses);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 3u);
-////    test_block_exists(instance, 3, *block3_ptr, settings.index_addresses);
-////    test_block_exists(instance, 2, *block2_ptr, settings.index_addresses);
-////
-////    std::cout << "insert block #2 (store_block_invalid_height)" << std::endl;
-////    BOOST_REQUIRE_EQUAL(instance.push(*block2_ptr, 2), error::store_block_invalid_height);
-////
-////    std::cout << "pop_above block 1 (blocks #2 & #3)" << std::endl;
-////    const auto blocks_popped_ptr = std::make_shared<block_const_ptr_list>();
-////    BOOST_REQUIRE_EQUAL(pop_above_result(instance, blocks_popped_ptr, { block1.hash(), 1 }, dispatch), error::success);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 1u);
-////    BOOST_REQUIRE_EQUAL(blocks_popped_ptr->size(), 2u);
-////    BOOST_REQUIRE(*(*blocks_popped_ptr)[0] == *block2_ptr);
-////    BOOST_REQUIRE(*(*blocks_popped_ptr)[1] == *block3_ptr);
-////    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
-////    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
-////    test_block_exists(instance, 1, block1, settings.index_addresses);
-////    test_block_exists(instance, 0, block0, settings.index_addresses);
-////
-////    std::cout << "push block #3 (store_block_invalid_height)" << std::endl;
-////    BOOST_REQUIRE_EQUAL(instance.push(*block3_ptr, 3), error::store_block_invalid_height);
-////
-////    std::cout << "insert block #2" << std::endl;
-////    BOOST_REQUIRE_EQUAL(instance.push(*block2_ptr, 2), error::success);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 2u);
-////
-////    std::cout << "pop_above block 0 (block #1 & #2)" << std::endl;
-////    blocks_popped_ptr->clear();
-////    BOOST_REQUIRE_EQUAL(pop_above_result(instance, blocks_popped_ptr, { block0.hash(), 0 }, dispatch), error::success);
-////    BOOST_REQUIRE(instance.blocks().top(height, false));
-////    BOOST_REQUIRE_EQUAL(height, 0u);
-////    BOOST_REQUIRE(*(*blocks_popped_ptr)[0] == block1);
-////    BOOST_REQUIRE(*(*blocks_popped_ptr)[1] == *block2_ptr);
-////    test_block_not_exists(instance, block1, settings.index_addresses);
-////    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
-////    test_block_exists(instance, 0, block0, settings.index_addresses);
-////
-////    std::cout << "end push/pop test" << std::endl;
-////}
-////
-////BOOST_AUTO_TEST_SUITE_END()
+/**
+* Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
+*
+* This file is part of libbitcoin.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <boost/test/unit_test.hpp>
+
+#include <future>
+#include <memory>
+#include <boost/filesystem.hpp>
+#include <bitcoin/database.hpp>
+#include "utility/utility.hpp"
+
+using namespace bc;
+using namespace bc::chain;
+using namespace bc::database;
+using namespace bc::wallet;
+using namespace boost::system;
+using namespace boost::filesystem;
+
+static void
+test_block_exists(const data_base& interface, size_t height,
+                       const block& block, bool index_addresses, bool candidate)
+{
+   const auto& address_store = interface.addresses();
+   const auto block_hash = block.hash();
+   auto result = interface.blocks().get(height, candidate);
+   auto result_by_hash = interface.blocks().get(block_hash);
+
+   BOOST_REQUIRE(result);
+   BOOST_REQUIRE(result_by_hash);
+   BOOST_REQUIRE(result.hash() == block_hash);
+   BOOST_REQUIRE(result_by_hash.hash() == block_hash);
+   BOOST_REQUIRE_EQUAL(result.height(), height);
+   BOOST_REQUIRE_EQUAL(result_by_hash.height(), height);
+   BOOST_REQUIRE_EQUAL(result.transaction_count(), block.transactions().size());
+   BOOST_REQUIRE_EQUAL(result_by_hash.transaction_count(), block.transactions().size());
+
+   // TODO: test tx offsets (vs. tx hashes).
+
+   for (size_t i = 0; i < block.transactions().size(); ++i)
+   {
+       const auto& tx = block.transactions()[i];
+       const auto tx_hash = tx.hash();
+       ////BOOST_REQUIRE(result.transaction_hash(i) == tx_hash);
+       ////BOOST_REQUIRE(result_by_hash.transaction_hash(i) == tx_hash);
+
+       auto result_tx = interface.transactions().get(tx_hash);
+       BOOST_REQUIRE(result_tx);
+       BOOST_REQUIRE(result_by_hash);
+       BOOST_REQUIRE(result_tx.transaction().hash() == tx_hash);
+       BOOST_REQUIRE_EQUAL(result_tx.height(), height);
+       BOOST_REQUIRE_EQUAL(result_tx.position(), i);
+
+       if (!tx.is_coinbase())
+       {
+           for (auto j = 0u; j < tx.inputs().size(); ++j)
+           {
+               const auto& input = tx.inputs()[j];
+               input_point spend{ tx_hash, j };
+               BOOST_REQUIRE_EQUAL(spend.index(), j);
+
+               if (!index_addresses)
+                   continue;
+
+               const auto addresses = input.addresses();
+               const auto& prevout = input.previous_output();
+               ////const auto address = prevout.metadata.cache.addresses();
+
+               for (const payment_address& address: addresses)
+               {
+                   auto history = address_store.get(address.hash());
+                   auto found = false;
+
+                   for (const payment_record& row: history)
+                   {
+                       if (row.hash() == tx_hash && row.index() == j)
+                       {
+                           BOOST_REQUIRE_EQUAL(row.height(), height);
+                           found = true;
+                           break;
+                       }
+                   }
+
+                   BOOST_REQUIRE(found);
+               }
+           }
+       }
+
+       if (!index_addresses)
+           return;
+
+       for (size_t j = 0; j < tx.outputs().size(); ++j)
+       {
+           const auto& output = tx.outputs()[j];
+           output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
+           const auto addresses = output.addresses();
+
+           for (const payment_address& address: addresses)
+           {
+               auto history = address_store.get(address.hash());
+               auto found = false;
+               
+               for (const payment_record& row: history)
+               {
+                   BOOST_REQUIRE(row.is_valid());
+
+                   if (row.hash() == tx_hash && row.index() == j)
+                   {
+                       BOOST_REQUIRE_EQUAL(row.height(), height);
+                       BOOST_REQUIRE_EQUAL(row.data(), output.value());
+                       found = true;
+                       break;
+                   }
+               }
+
+               BOOST_REQUIRE(found);
+           }
+       }
+   }
+}
+
+// static void
+// test_block_not_exists(const data_base& interface, const block& block0,
+//    bool index_addresses)
+// {
+//    const auto& address_store = interface.history();
+
+//    // Popped blocks still exist in the block hash table, but not confirmed.
+//    const auto block_hash = block0.hash();
+//    const auto result = interface.blocks().get(block_hash);
+//    BOOST_REQUIRE(!is_confirmed(result.state()));
+
+//    for (size_t i = 0; i < block0.transactions().size(); ++i)
+//    {
+//        const auto& tx = block0.transactions()[i];
+//        const auto tx_hash = tx.hash();
+
+//        if (!tx.is_coinbase())
+//        {
+//            for (size_t j = 0; j < tx.inputs().size(); ++j)
+//            {
+//                const auto& input = tx.inputs()[j];
+//                input_point spend{ tx_hash, static_cast<uint32_t>(j) };
+//                auto r0_spend = interface.spends().get(input.previous_output());
+//                BOOST_REQUIRE(!r0_spend.is_valid());
+
+//                if (!index_addresses)
+//                    continue;
+
+//                const auto addresses = input.addresses();
+//                ////const auto& prevout = input.previous_output();
+//                ////const auto address = prevout.metadata.cache.addresses();
+
+//                for (const auto& address: addresses)
+//                {
+//                    auto history = address_store.get(address.hash(), 0, 0);
+//                    auto found = false;
+
+//                    for (const auto& row: history)
+//                    {
+//                        if (row.point() == spend)
+//                        {
+//                            found = true;
+//                            break;
+//                        }
+//                    }
+
+//                    BOOST_REQUIRE(!found);
+//                }
+//            }
+//        }
+
+//        if (!index_addresses)
+//            return;
+
+//        for (size_t j = 0; j < tx.outputs().size(); ++j)
+//        {
+//            const auto& output = tx.outputs()[j];
+//            output_point outpoint{ tx_hash, static_cast<uint32_t>(j) };
+//            const auto addresses = output.addresses();
+
+//            for (const auto& address: addresses)
+//            {
+//                auto history = address_store.get(address.hash(), 0, 0);
+//                auto found = false;
+
+//                for (const auto& row: history)
+//                {
+//                    if (row.point() == outpoint)
+//                    {
+//                        found = true;
+//                        break;
+//                    }
+//                }
+
+//                BOOST_REQUIRE(!found);
+//            }
+//        }
+//    }
+// }
+
+static chain_state::data
+data_for_chain_state()
+{
+    chain_state::data value;
+    value.height = 1;
+    value.bits = { 0, { 0 } };
+    value.version = { 1, { 0 } };
+    value.timestamp = { 0, 0, { 0 } };
+    return value;
+}
+
+static void
+set_state(block& block) {
+    auto state = std::make_shared<chain_state>(
+        chain_state{ data_for_chain_state(), {}, 0, 0, bc::settings() });
+    block.header().metadata.state = state;
+}
+
+static block
+read_block(const std::string hex)
+{
+   data_chunk data;
+   BOOST_REQUIRE(decode_base16(data, hex));
+   block result;
+   BOOST_REQUIRE(result.from_data(data));
+   set_state(result);
+   return result;
+}
+
+static void
+store_block_transactions(data_base& instance, const block& block, size_t forks) {
+   for (const auto& tx: block.transactions()) {
+       instance.store(tx, forks);
+   }
+}
+
+#define DIRECTORY "data_base"
+
+struct data_base_setup_fixture
+{
+    data_base_setup_fixture()
+    {
+        test::clear_path(DIRECTORY);
+    }
+    
+    ~data_base_setup_fixture()
+    {
+        test::clear_path(DIRECTORY);
+    }
+};
+
+
+BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
+
+#define TRANSACTION1 "0100000001537c9d05b5f7d67b09e5108e3bd5e466909cc9403ddd98bc42973f366fe729410600000000ffffffff0163000000000000001976a914fe06e7b4c88a719e92373de489c08244aee4520b88ac00000000"
+
+#define MAINNET_BLOCK1 \
+"010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982" \
+"051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff00" \
+"1d01e3629901010000000100000000000000000000000000000000000000000000000000000" \
+"00000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e8" \
+"53519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a60" \
+"4f8141781e62294721166bf621e73a82cbf2342c858eeac00000000"
+
+#define MAINNET_BLOCK2 \
+"010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5f" \
+"dcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff00" \
+"1d08d2bd6101010000000100000000000000000000000000000000000000000000000000000" \
+"00000000000ffffffff0704ffff001d010bffffffff0100f2052a010000004341047211a824" \
+"f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385" \
+"237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000"
+
+#define MAINNET_BLOCK3 \
+"01000000bddd99ccfda39da1b108ce1a5d70038d0a967bacb68b6b63065f626a0000000044f" \
+"672226090d85db9a9f2fbfe5f0f9609b387af7be5b7fbb7a1767c831c9e995dbe6649ffff00" \
+"1d05e0ed6d01010000000100000000000000000000000000000000000000000000000000000" \
+"00000000000ffffffff0704ffff001d010effffffff0100f2052a0100000043410494b9d3e7" \
+"6c5b1629ecf97fff95d7a4bbdac87cc26099ada28066c6ff1eb9191223cd897194a08d0c272" \
+"6c5747f1db49e8cf90e75dc3e3550ae9b30086f3cd5aaac00000000"
+
+class data_base_accessor
+ : public data_base
+{
+public:
+    data_base_accessor(const bc::database::settings& settings)
+        : data_base(settings)
+    {
+    }
+
+    bool push_all(block_const_ptr_list_const_ptr blocks, const config::checkpoint& fork_point)
+    {
+        return data_base::push_all(blocks, fork_point);
+    }
+
+    bool push_all(header_const_ptr_list_const_ptr headers, const config::checkpoint& fork_point)
+    {
+        return data_base::push_all(headers, fork_point);
+    }
+    
+    code push_header(const header& header, size_t height, uint32_t mtp)
+    {
+        return data_base::push_header(header, height, mtp);
+    }
+
+    code push_block(const block& block, size_t height)
+    {
+        return data_base::push_block(block, height);
+    }
+    
+    code store(const transaction& tx, uint32_t forks)
+    {
+        return data_base::store(tx, forks);
+    }
+    
+};
+
+static void
+test_heights(const data_base& instance, size_t candidate_height_in, size_t confirmed_height_in)
+{    
+    size_t candidate_height = 0u;
+    size_t confirmed_height = 0u;
+    BOOST_REQUIRE(instance.blocks().top(candidate_height, true));
+    BOOST_REQUIRE(instance.blocks().top(confirmed_height, false));
+    
+    BOOST_REQUIRE_EQUAL(candidate_height, candidate_height_in);
+    BOOST_REQUIRE_EQUAL(confirmed_height, confirmed_height_in);   
+}
+
+// static code pop_above_result(data_base_accessor& instance,
+//    block_const_ptr_list_ptr out_blocks, const config::checkpoint& fork_point,
+//    dispatcher& dispatch)
+// {
+//    std::promise<code> promise;
+//    const auto handler = [&promise](code ec)
+//    {
+//        promise.set_value(ec);
+//    };
+//    instance.pop_above(out_blocks, fork_point, dispatch, handler);
+//    return promise.get_future().get();
+// }
+
+// static code push_all_result(data_base_accessor& instance,
+//    block_const_ptr_list_const_ptr in_blocks, size_t index, size_t height,
+//    dispatcher& dispatch)
+// {
+//    std::promise<code> promise;
+//    const auto handler = [&promise](code ec)
+//    {
+//        promise.set_value(ec);
+//    };
+//    instance.push_next(in_blocks, index, height, dispatch, handler);
+//    return promise.get_future().get();
+// }
+
+BOOST_AUTO_TEST_CASE(data_base__create__block_transactions_index_interaction__success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+  
+   data_base instance(settings); 
+   
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+   
+   test_heights(instance, 0u, 0u);
+
+   transaction tx1;
+   data_chunk wire_tx1;
+   BOOST_REQUIRE(decode_base16(wire_tx1, TRANSACTION1));
+   BOOST_REQUIRE(tx1.from_data(wire_tx1));
+
+   const auto hash1 = tx1.hash();
+   BOOST_REQUIRE(!instance.transactions().get(hash1));   
+}
+
+BOOST_AUTO_TEST_CASE(data_base__create__genesis_block_available__success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+  
+   data_base instance(settings); 
+   
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   test_block_exists(instance, 0, genesis, settings.index_addresses, false);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push__adds_to_blocks_and_transactions_validates_and_confirms__success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+  
+   data_base instance(settings); 
+   
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+
+   const auto block1 = read_block(MAINNET_BLOCK1);   
+
+   // setup ends
+   
+   BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
+
+   // test conditions
+   
+   test_block_exists(instance, 1, block1, settings.index_addresses, false);
+   test_heights(instance, 1u, 1u);
+}
+
+// BLOCK ORGANIZER tests
+// ----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___fails)
+{
+    create_directory(DIRECTORY);
+    database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.index_addresses = false;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+    
+    data_base_accessor instance(settings); 
+    
+    static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+    const chain::block genesis = bc_settings.genesis_block;
+    BOOST_REQUIRE(instance.create(genesis));
+    
+    const auto block1 = read_block(MAINNET_BLOCK1);
+    store_block_transactions(instance, block1, 1);
+    
+    // setup ends
+    
+    BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::operation_failed);
+    test_heights(instance, 0u, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+  
+   data_base_accessor instance(settings); 
+   
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+   
+   const auto block1 = read_block(MAINNET_BLOCK1);
+   store_block_transactions(instance, block1, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
+   BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
+   test_heights(instance, 1u, 0u);
+
+   // setup ends
+   
+   BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
+   BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
+
+   // test conditions
+
+   test_heights(instance, 1u, 1u);
+   test_block_exists(instance, 1, block1, settings.index_addresses, false);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__push_all_and_update__already_candidated___success)
+{
+   create_directory(DIRECTORY);
+   database::settings settings;
+   settings.directory = DIRECTORY;
+   settings.index_addresses = false;
+   settings.flush_writes = false;
+   settings.file_growth_rate = 42;
+   settings.block_table_buckets = 42;
+   settings.transaction_table_buckets = 42;
+   settings.address_table_buckets = 42;
+  
+   data_base_accessor instance(settings); 
+   
+   static const auto bc_settings = bc::settings(bc::config::settings::mainnet);
+   const chain::block genesis = bc_settings.genesis_block;
+   BOOST_REQUIRE(instance.create(genesis));
+   
+   const auto block1 = read_block(MAINNET_BLOCK1);
+
+   block_const_ptr block1_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK1));
+   block_const_ptr block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
+   block_const_ptr block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
+   const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{
+           block1_ptr, block2_ptr, block3_ptr });
+   store_block_transactions(instance, *block1_ptr, 1);
+   store_block_transactions(instance, *block2_ptr, 1);
+   store_block_transactions(instance, *block3_ptr, 1);
+
+   const auto headers_push_ptr = std::make_shared<const header_const_ptr_list>(header_const_ptr_list{
+           std::make_shared<const message::header>(block1_ptr->header()),
+               std::make_shared<const message::header>(block2_ptr->header()),
+               std::make_shared<const message::header>(block3_ptr->header())
+               });
+      
+   BOOST_REQUIRE(instance.push_all(headers_push_ptr, config::checkpoint(genesis.hash(), 0)));
+   for(const auto block_ptr: *blocks_push_ptr) {
+       BOOST_REQUIRE_EQUAL(instance.candidate(*block_ptr), error::success);
+   }
+
+   test_heights(instance, 3u, 0u);
+
+   // setup ends
+   
+   BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
+   BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
+   BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
+   BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
+
+   // test conditions
+
+   test_heights(instance, 3u, 3u);
+   test_block_exists(instance, 1, *block1_ptr, settings.index_addresses, false);
+   test_block_exists(instance, 2, *block2_ptr, settings.index_addresses, false);
+   test_block_exists(instance, 3, *block3_ptr, settings.index_addresses, false);
+}
+
+// BOOST_AUTO_TEST_CASE(data_base__pushpop__test)
+// {
+//    std::cout << "begin data_base push/pop test" << std::endl;
+
+//    create_directory(DIRECTORY);
+//    database::settings settings;
+//    settings.directory = DIRECTORY;
+//    settings.index_addresses = true;
+//    settings.flush_writes = false;
+//    settings.file_growth_rate = 42;
+//    settings.block_table_buckets = 42;
+//    settings.transaction_table_buckets = 42;
+//    settings.address_table_buckets = 42;
+
+//    size_t height;
+//    threadpool pool(1);
+//    dispatcher dispatch(pool, "test");
+//    data_base_accessor instance(settings);
+//    const auto block0 = block::genesis_mainnet();
+//    BOOST_REQUIRE(instance.create(block0));
+//    test_block_exists(instance, 0, block0, settings.index_addresses);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 0);
+
+//    // This tests a missing parent, not a database failure.
+//    // A database failure would prevent subsequent read/write operations.
+//    std::cout << "push block #1 (store_block_missing_parent)" << std::endl;
+//    auto invalid_block1 = read_block(MAINNET_BLOCK1);
+//    invalid_block1.set_header(chain::header{});
+//    BOOST_REQUIRE_EQUAL(instance.push(invalid_block1, 1), error::store_block_missing_parent);
+
+//    std::cout << "push block #1" << std::endl;
+//    const auto block1 = read_block(MAINNET_BLOCK1);
+//    test_block_not_exists(instance, block1, settings.index_addresses);
+//    BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
+//    test_block_exists(instance, 0, block0, settings.index_addresses);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 1u);
+//    test_block_exists(instance, 1, block1, settings.index_addresses);
+
+//    std::cout << "push_all blocks #2 & #3" << std::endl;
+//    const auto block2_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK2));
+//    const auto block3_ptr = std::make_shared<const message::block>(read_block(MAINNET_BLOCK3));
+//    const auto blocks_push_ptr = std::make_shared<const block_const_ptr_list>(block_const_ptr_list{ block2_ptr, block3_ptr });
+//    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
+//    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
+//    BOOST_REQUIRE_EQUAL(push_all_result(instance, blocks_push_ptr, 0, 2, dispatch), error::success);
+//    test_block_exists(instance, 1, block1, settings.index_addresses);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 3u);
+//    test_block_exists(instance, 3, *block3_ptr, settings.index_addresses);
+//    test_block_exists(instance, 2, *block2_ptr, settings.index_addresses);
+
+//    std::cout << "insert block #2 (store_block_invalid_height)" << std::endl;
+//    BOOST_REQUIRE_EQUAL(instance.push(*block2_ptr, 2), error::store_block_invalid_height);
+
+//    std::cout << "pop_above block 1 (blocks #2 & #3)" << std::endl;
+//    const auto blocks_popped_ptr = std::make_shared<block_const_ptr_list>();
+//    BOOST_REQUIRE_EQUAL(pop_above_result(instance, blocks_popped_ptr, { block1.hash(), 1 }, dispatch), error::success);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 1u);
+//    BOOST_REQUIRE_EQUAL(blocks_popped_ptr->size(), 2u);
+//    BOOST_REQUIRE(*(*blocks_popped_ptr)[0] == *block2_ptr);
+//    BOOST_REQUIRE(*(*blocks_popped_ptr)[1] == *block3_ptr);
+//    test_block_not_exists(instance, *block3_ptr, settings.index_addresses);
+//    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
+//    test_block_exists(instance, 1, block1, settings.index_addresses);
+//    test_block_exists(instance, 0, block0, settings.index_addresses);
+
+//    std::cout << "push block #3 (store_block_invalid_height)" << std::endl;
+//    BOOST_REQUIRE_EQUAL(instance.push(*block3_ptr, 3), error::store_block_invalid_height);
+
+//    std::cout << "insert block #2" << std::endl;
+//    BOOST_REQUIRE_EQUAL(instance.push(*block2_ptr, 2), error::success);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 2u);
+
+//    std::cout << "pop_above block 0 (block #1 & #2)" << std::endl;
+//    blocks_popped_ptr->clear();
+//    BOOST_REQUIRE_EQUAL(pop_above_result(instance, blocks_popped_ptr, { block0.hash(), 0 }, dispatch), error::success);
+//    BOOST_REQUIRE(instance.blocks().top(height, false));
+//    BOOST_REQUIRE_EQUAL(height, 0u);
+//    BOOST_REQUIRE(*(*blocks_popped_ptr)[0] == block1);
+//    BOOST_REQUIRE(*(*blocks_popped_ptr)[1] == *block2_ptr);
+//    test_block_not_exists(instance, block1, settings.index_addresses);
+//    test_block_not_exists(instance, *block2_ptr, settings.index_addresses);
+//    test_block_exists(instance, 0, block0, settings.index_addresses);
+
+//    std::cout << "end push/pop test" << std::endl;
+// }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -607,8 +607,9 @@ BOOST_AUTO_TEST_CASE(data_base__pop_header_not_top___fails)
    const auto block1 = read_block(MAINNET_BLOCK1);
 
    // setup ends
-   
-   BOOST_REQUIRE_EQUAL(instance.pop_header(const_cast<header&>(block1.header()), 1), error::operation_failed);
+
+   chain::header out_header;
+   BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::operation_failed);
 }
 
 BOOST_AUTO_TEST_CASE(data_base__pop_header__existing___success)
@@ -636,11 +637,13 @@ BOOST_AUTO_TEST_CASE(data_base__pop_header__existing___success)
    BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
 
    // setup ends
-   
-   BOOST_REQUIRE_EQUAL(instance.pop_header(const_cast<header&>(block1.header()), 1), error::success);
+
+   chain::header out_header;
+   BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::success);
 
    // test conditions
 
+   BOOST_REQUIRE(out_header.hash() == block1.header().hash());
    test_heights(instance, 0u, 0u);
 }
 

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -133,8 +133,8 @@ static void test_block_exists(const data_base& interface, size_t height,
     }
 }
 
-static void test_block_not_exists(const data_base& interface, const block& block0,
-    bool index_addresses)
+static void test_block_not_exists(const data_base& interface,
+    const block& block0, bool index_addresses)
 {
     const auto& address_store = interface.addresses();
 
@@ -223,7 +223,7 @@ static chain_state::data data_for_chain_state()
 static void set_state(block& block)
 {
     auto state = std::make_shared<chain_state>(
-        chain_state{ data_for_chain_state(), {}, 0, 0, bc::system::settings() });
+        chain_state{ data_for_chain_state(), {}, 0, 0, {} });
     block.header().metadata.state = state;
 }
 

--- a/test/primitives/hash_table_multimap.cpp
+++ b/test/primitives/hash_table_multimap.cpp
@@ -87,7 +87,6 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
 
     const auto found2 = multimap.find(key);
     BOOST_REQUIRE(found2);
-    BOOST_REQUIRE(multimap.find(link2));
 
     // elements in index are correctly linked
     BOOST_REQUIRE_EQUAL(found2.next(), found.link());


### PR DESCRIPTION
- Restructured push_pop tests and using the v4 data_base methods now
- Still need to add tests for reorganize, invalidate and index public methods
- I ran into NDEBUG some issues with the way ndebug is setup and used.

I am happy for this PR to be merged, pending a review. I can look at the ndebug issue in another PR once we decide if and what changes are required.

### The ndebug issue

Not all configs on travis have --disable-ndebug, and that results in tests having to deal with different error codes returned from methods called. For now, I am using preprocessor directives to check for appropriate returned values or in one case completely skip a test.

We could do one of the two things:

1. Change travis configs to all have --disable-ndebug, or
2. Streamline returned values so that they are the same with or without ndebug being defined
3. We can continue with preprocessor directives as I am doing now

I think we can fix this concern, if needed, in a separate PR. 