### PR TITLE
Change hash_table::find(Link) to return not_found list_element when reading past eof

### DIFF
--- a/include/bitcoin/database/impl/hash_table.ipp
+++ b/include/bitcoin/database/impl/hash_table.ipp
@@ -93,6 +93,9 @@ template <typename Manager, typename Index, typename Link, typename Key>
 typename hash_table<Manager, Index, Link, Key>::const_value_type
 hash_table<Manager, Index, Link, Key>::find(Link link) const
 {
+    if (manager_.past_eof(link))
+        return { manager_, not_found, list_mutex_ };
+
     return { manager_, link, list_mutex_ };
 }
 
@@ -100,7 +103,7 @@ template <typename Manager, typename Index, typename Link, typename Key>
 typename hash_table<Manager, Index, Link, Key>::const_value_type
 hash_table<Manager, Index, Link, Key>::terminator() const
 {
-    return find(not_found);
+    return { manager_, not_found, list_mutex_ };
 }
 
 template <typename Manager, typename Index, typename Link, typename Key>

--- a/include/bitcoin/database/impl/hash_table.ipp
+++ b/include/bitcoin/database/impl/hash_table.ipp
@@ -95,8 +95,7 @@ hash_table<Manager, Index, Link, Key>::find(Link link) const
 {
     // Ensure requested position is within the file.
     // We avoid a runtime error here to optimize out the past_eof locks.
-    BITCOIN_ASSERT_MSG(link == not_found || !manager_.past_eof(link),
-        "Read past end of file.");
+    BITCOIN_ASSERT_MSG(!manager_.past_eof(link), "Read past end of file.");
 
     return { manager_, link, list_mutex_ };
 }

--- a/include/bitcoin/database/impl/hash_table.ipp
+++ b/include/bitcoin/database/impl/hash_table.ipp
@@ -93,8 +93,10 @@ template <typename Manager, typename Index, typename Link, typename Key>
 typename hash_table<Manager, Index, Link, Key>::const_value_type
 hash_table<Manager, Index, Link, Key>::find(Link link) const
 {
-    if (manager_.past_eof(link))
-        return { manager_, not_found, list_mutex_ };
+    // Ensure requested position is within the file.
+    // We avoid a runtime error here to optimize out the past_eof locks.
+    BITCOIN_ASSERT_MSG(link == not_found || !manager_.past_eof(link),
+        "Read past end of file.");
 
     return { manager_, link, list_mutex_ };
 }

--- a/include/bitcoin/database/impl/record_manager.ipp
+++ b/include/bitcoin/database/impl/record_manager.ipp
@@ -134,13 +134,18 @@ Link record_manager<Link>::allocate(size_t count)
 template <typename Link>
 memory_ptr record_manager<Link>::get(Link link) const
 {
-    // If record >= count() then we should still be within the file. The
-    // condition implies a block has been unconfirmed while reading it.
+    BITCOIN_ASSERT_MSG(link < count(), "Read past end of file.");
 
     // The accessor must remain in scope until the end of the block.
     const auto memory = file_.access();
     memory->increment(header_size_ + link_to_position(link));
     return memory;
+}
+
+template <typename Link>
+bool record_manager<Link>::past_eof(Link link) const
+{
+    return link >= count();
 }
 
 // privates

--- a/include/bitcoin/database/impl/slab_manager.ipp
+++ b/include/bitcoin/database/impl/slab_manager.ipp
@@ -130,6 +130,12 @@ memory_ptr slab_manager<Link>::get(Link link) const
     return memory;
 }
 
+template <typename Link>
+bool slab_manager<Link>::past_eof(Link link) const
+{
+    return link >= payload_size();
+}
+
 // privates
 
 // Read the size value from the first 64 bits of the file after the header.

--- a/include/bitcoin/database/primitives/record_manager.hpp
+++ b/include/bitcoin/database/primitives/record_manager.hpp
@@ -58,6 +58,9 @@ public:
     /// Change the number of records of this container (truncation).
     void set_count(Link value);
 
+    /// Check if link is past eof
+    bool past_eof(Link link) const;
+
     /// Allocate records and return first logical index, commit after writing.
     Link allocate(size_t count);
 

--- a/include/bitcoin/database/primitives/slab_manager.hpp
+++ b/include/bitcoin/database/primitives/slab_manager.hpp
@@ -57,6 +57,9 @@ public:
     /// Allocate a slab and return its position, commit after writing.
     Link allocate(size_t size);
 
+    /// Check if link is past eof
+    bool past_eof(Link link) const;
+
     /// Return memory object for the slab at the specified position.
     memory_ptr get(Link position) const;
 

--- a/src/databases/block_database.cpp
+++ b/src/databases/block_database.cpp
@@ -174,12 +174,13 @@ bool block_database::top(size_t& out_height, bool candidate) const
 block_result block_database::get(size_t height, bool candidate) const
 {
     auto& manager = candidate ? candidate_index_ : confirmed_index_;
-    const auto link = height < manager.count() ? read_index(height, manager) :
-        hash_table_.not_found;
+    const auto element = height < manager.count()
+        ? hash_table_.find(read_index(height, manager))
+        : hash_table_.terminator();
 
     return
     {
-        hash_table_.find(link),
+        element,
         metadata_mutex_,
         tx_index_
     };
@@ -441,9 +442,6 @@ bool block_database::unindex(const hash_digest& DEBUG_ONLY(hash), size_t height,
 
     // Unconfirmation implies that block is indexed, so use index.
     auto element = hash_table_.find(read_index(height, manager));
-
-    if (!element)
-        return false;
 
     BITCOIN_ASSERT(hash == element.key());
 

--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -139,6 +139,7 @@ bool transaction_database::close()
 
 transaction_result transaction_database::get(file_offset offset) const
 {
+    // This is not guarded for an invalid offset.
     return { hash_table_.find(offset), metadata_mutex_ };
 }
 

--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -139,7 +139,6 @@ bool transaction_database::close()
 
 transaction_result transaction_database::get(file_offset offset) const
 {
-    // This is not guarded for an invalid offset.
     return { hash_table_.find(offset), metadata_mutex_ };
 }
 

--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -329,9 +329,6 @@ bool transaction_database::candidate(file_offset link, bool positive)
 {
     const auto result = get(link);
 
-    if (!result)
-        return false;
-
     // Spend or unspend the candidate tx's previous outputs.
     for (const auto inpoint: result)
         if (!candidate_spend(inpoint, positive))
@@ -403,9 +400,6 @@ bool transaction_database::candidate_spend(const chain::output_point& point,
 bool transaction_database::candidize(link_type link, bool positive)
 {
     const auto element = hash_table_.find(link);
-
-    if (!element)
-        return false;
 
     const auto writer = [&](byte_serializer& serial)
     {
@@ -551,9 +545,6 @@ bool transaction_database::confirmize(link_type link, size_t height,
     BITCOIN_ASSERT(height <= max_uint32);
     BITCOIN_ASSERT(position <= max_uint16);
     const auto element = hash_table_.find(link);
-
-    if (!element)
-        return false;
 
     const auto writer = [&](byte_serializer& serial)
     {

--- a/test/databases/block_database.cpp
+++ b/test/databases/block_database.cpp
@@ -58,6 +58,24 @@ struct block_database_directory_setup_fixture
 
 BOOST_FIXTURE_TEST_SUITE(block_database_tests, block_database_directory_setup_fixture)
 
+BOOST_AUTO_TEST_CASE(block_database__get__not_found__success)
+{
+    const auto block_table = DIRECTORY "/block_table";
+    const auto candidate_index = DIRECTORY "/candidate_index";
+    const auto confirmed_index = DIRECTORY "/confirmed_index";
+    const auto tx_index = DIRECTORY "/tx_index";
+
+    test::create(block_table);
+    test::create(candidate_index);
+    test::create(confirmed_index);
+    test::create(tx_index);
+    block_database instance(block_table, candidate_index, confirmed_index, tx_index, 1, 1, 1, 1, 1000, 50);
+    BOOST_REQUIRE(instance.create());
+
+    BOOST_REQUIRE(!instance.get(0, true));
+    BOOST_REQUIRE(!instance.get(0, false));
+}
+
 BOOST_AUTO_TEST_CASE(block_database__test)
 {
     // TODO: replace.

--- a/test/primitives/hash_table_multimap.cpp
+++ b/test/primitives/hash_table_multimap.cpp
@@ -53,10 +53,10 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__find__not_existing__not_found)
     // Create the multimap.
     record_multimap multimap(table, index);
 
-    // Test finding missing element
+    // Test finding missing element.
     BOOST_REQUIRE(!multimap.find(key));
 
-    // Test finding element past eof
+    // Test finding element past eof.
     BOOST_REQUIRE(!multimap.find(10u));
 }
 
@@ -109,14 +109,14 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
     const auto link = element.create(writer);
     multimap.link(key, element);
 
-    auto found = multimap.find(key);
+    const auto found = multimap.find(key);
     BOOST_REQUIRE(found);
-    auto found_from_link = multimap.find(link);
+    const auto found_from_link = multimap.find(link);
     BOOST_REQUIRE(found_from_link);
     BOOST_REQUIRE_EQUAL(found_from_link.link(), link);
 
 
-    // Second element on the same key
+    // Second element on the same key.
     auto element2 = multimap.allocator();
     const auto link2 = element2.create(writer2);
     multimap.link(key, element2);
@@ -124,10 +124,10 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
     const auto found2 = multimap.find(key);
     BOOST_REQUIRE(found2);
 
-    // elements in index are correctly linked
+    // Elements in index are correctly linked.
     BOOST_REQUIRE_EQUAL(found2.next(), found.link());
 
-    // read the two elements
+    // Read the two elements.
     const auto reader = [](byte_deserializer& deserial)
     {
         BOOST_REQUIRE_EQUAL(deserial.read_byte(), 110u);
@@ -145,17 +145,17 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
     found.read(reader);
     found2.read(reader2);
 
-    // stored elements from index
+    // Stored elements from index.
     BOOST_REQUIRE(index.get(link));
     BOOST_REQUIRE(index.get(link2));
 
-    // Unlink once
+    // Unlink once.
     BOOST_REQUIRE(multimap.unlink(key));
 
     BOOST_REQUIRE(multimap.find(key));
     BOOST_REQUIRE(multimap.find(link));
 
-    // unlink the second time
+    // Unlink the second time.
     BOOST_REQUIRE(multimap.unlink(key));
 
     BOOST_REQUIRE(!multimap.find(key));

--- a/test/primitives/hash_table_multimap.cpp
+++ b/test/primitives/hash_table_multimap.cpp
@@ -27,6 +27,39 @@ using namespace bc::database;
 
 BOOST_AUTO_TEST_SUITE(hash_table_multimap_tests)
 
+BOOST_AUTO_TEST_CASE(hash_table_multimap__find__not_existing__not_found)
+{
+    // Define multimap type.
+    typedef test::tiny_hash key_type;
+    typedef uint32_t index_type;
+    typedef uint32_t link_type;
+    typedef record_manager<link_type> record_manager;
+    typedef hash_table<record_manager, index_type, link_type, key_type> record_map;
+    typedef hash_table_multimap<index_type, link_type, key_type> record_multimap;
+
+    const auto value_size = 3u;
+    const key_type key{ { 0xde, 0xad, 0xbe, 0xef } };
+
+    test::storage hash_table_file;
+    BOOST_REQUIRE(hash_table_file.open());
+    record_map table(hash_table_file, 100u, sizeof(link_type));
+    BOOST_REQUIRE(table.create());
+
+    // Create the file and initialize index.
+    test::storage index_file;
+    BOOST_REQUIRE(index_file.open());
+    record_manager index(index_file, 0, record_multimap::size(value_size));
+
+    // Create the multimap.
+    record_multimap multimap(table, index);
+
+    // Test finding missing element
+    BOOST_REQUIRE(!multimap.find(key));
+
+    // Test finding element past eof
+    BOOST_REQUIRE(!multimap.find(10u));
+}
+
 BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
 {
     // Define multimap type.
@@ -78,7 +111,10 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)
 
     auto found = multimap.find(key);
     BOOST_REQUIRE(found);
-    BOOST_REQUIRE(multimap.find(link));
+    auto found_from_link = multimap.find(link);
+    BOOST_REQUIRE(found_from_link);
+    BOOST_REQUIRE_EQUAL(found_from_link.link(), link);
+
 
     // Second element on the same key
     auto element2 = multimap.allocator();

--- a/test/primitives/hash_table_multimap.cpp
+++ b/test/primitives/hash_table_multimap.cpp
@@ -55,9 +55,6 @@ BOOST_AUTO_TEST_CASE(hash_table_multimap__find__not_existing__not_found)
 
     // Test finding missing element.
     BOOST_REQUIRE(!multimap.find(key));
-
-    // Test finding element past eof.
-    BOOST_REQUIRE(!multimap.find(10u));
 }
 
 BOOST_AUTO_TEST_CASE(hash_table_multimap__construct__always__expected)


### PR DESCRIPTION
Ref: Issue: https://github.com/libbitcoin/libbitcoin-database/issues/241

The PR contains a proposal to change the hash_table and hash_table_multimap find(Link) methods so that they return a list_element with a not_found sentinel when the link is past eof.

For record_manager we check the record_count_ and for slab_manager we check the payload_size_.

The change will help the calls to find(Link), especially in transaction_database where find(Link) is used without checking if the link is past eof.

The downside is that all calls to find will acquire a lock to check the record_count/payload_size.

My concern in the issue linked above about count being reduced on pop_index is not really a concern any more. My understanding now is that if a the index record_manager counts are reduced then find with offsets greater than the record count should return a not_found list_element.