### PR TITLE
Add spender_height != not_spent to confirmed spent metadata pop.

### DIFF
--- a/include/bitcoin/database/databases/transaction_database.hpp
+++ b/include/bitcoin/database/databases/transaction_database.hpp
@@ -84,9 +84,9 @@ public:
     void get_pool_metadata(const system::chain::transaction& tx,
         uint32_t forks) const;
 
-    /// Populate output metadata for the specified point and given context.
+    /// Populate output metadata for the specified point and fork point.
     bool get_output(const system::chain::output_point& point,
-        size_t fork_height, bool candidate) const;
+        size_t fork_height) const;
 
     // Writers.
     // ------------------------------------------------------------------------

--- a/include/bitcoin/database/result/transaction_result.hpp
+++ b/include/bitcoin/database/result/transaction_result.hpp
@@ -79,8 +79,8 @@ public:
     /// All tx outputs confirmed below fork or as candidates.
     bool is_candidate_spent(size_t fork_height) const;
 
-    /// All tx outputs confirmed below fork.
-    bool is_confirmed_spent(size_t fork_height) const;
+    /////// All tx outputs confirmed below fork.
+    ////bool is_confirmed_spent(size_t fork_height) const;
 
     /// The output at the specified index within this transaction.
     system::chain::output output(uint32_t index) const;

--- a/include/bitcoin/database/result/transaction_result.hpp
+++ b/include/bitcoin/database/result/transaction_result.hpp
@@ -76,8 +76,11 @@ public:
     /// The median time past of the block which includes the transaction.
     uint32_t median_time_past() const;
 
-    /// All tx outputs confirmed below fork, or candidate as applicable.
-    bool is_spent(size_t fork_height, bool candidate) const;
+    /// All tx outputs confirmed below fork or as candidates.
+    bool is_candidate_spent(size_t fork_height) const;
+
+    /// All tx outputs confirmed below fork.
+    bool is_confirmed_spent(size_t fork_height) const;
 
     /// The output at the specified index within this transaction.
     system::chain::output output(uint32_t index) const;

--- a/src/result/transaction_result.cpp
+++ b/src/result/transaction_result.cpp
@@ -117,12 +117,11 @@ uint32_t transaction_result::median_time_past() const
     return median_time_past_;
 }
 
-bool transaction_result::is_spent(size_t fork_height, bool candidate) const
+bool transaction_result::is_candidate_spent(size_t fork_height) const
 {
-    const auto confirmed = position_ != unconfirmed && height_ <= fork_height;
-
-    // Cannot be spent unless confirmed/candidate.
-    if (!confirmed && !candidate)
+    // Cannot be spent unless candidate or confirmed by fork height.
+    if (!candidate_ &&
+        ((position_ == unconfirmed) || (height_ > fork_height)))
         return false;
 
     BITCOIN_ASSERT(element_);
@@ -139,7 +138,36 @@ bool transaction_result::is_spent(size_t fork_height, bool candidate) const
         {
             // TODO: This reads full output, which is simple but not optimial.
             const auto output = output::factory(deserial, false);
-            spent = output.metadata.spent(fork_height, candidate_ && candidate);
+            spent = output.metadata.candidate_spent ||
+                output.metadata.confirmed_spent_height <= fork_height;
+        }
+    };
+
+    element_.read(reader);
+    return spent;
+}
+
+bool transaction_result::is_confirmed_spent(size_t fork_height) const
+{
+    // Cannot be spent unless confirmed by fork height.
+    if (!((position_ != unconfirmed) && (height_ <= fork_height)))
+        return false;
+
+    BITCOIN_ASSERT(element_);
+    auto spent = true;
+
+    // Spentness is unguarded and will be inconsistent during write.
+    const auto reader = [&](byte_deserializer& deserial)
+    {
+        deserial.skip(metadata_size);
+        const auto outputs = deserial.read_size_little_endian();
+
+        // Search all outputs for an unspent indication.
+        for (auto out = 0u; spent && out < outputs; ++out)
+        {
+            // TODO: This reads full output, which is simple but not optimial.
+            const auto output = output::factory(deserial, false);
+            spent = output.metadata.confirmed_spent_height <= fork_height;
         }
     };
 

--- a/src/result/transaction_result.cpp
+++ b/src/result/transaction_result.cpp
@@ -147,33 +147,33 @@ bool transaction_result::is_candidate_spent(size_t fork_height) const
     return spent;
 }
 
-bool transaction_result::is_confirmed_spent(size_t fork_height) const
-{
-    // Cannot be spent unless confirmed by fork height.
-    if (!((position_ != unconfirmed) && (height_ <= fork_height)))
-        return false;
-
-    BITCOIN_ASSERT(element_);
-    auto spent = true;
-
-    // Spentness is unguarded and will be inconsistent during write.
-    const auto reader = [&](byte_deserializer& deserial)
-    {
-        deserial.skip(metadata_size);
-        const auto outputs = deserial.read_size_little_endian();
-
-        // Search all outputs for an unspent indication.
-        for (auto out = 0u; spent && out < outputs; ++out)
-        {
-            // TODO: This reads full output, which is simple but not optimial.
-            const auto output = output::factory(deserial, false);
-            spent = output.metadata.confirmed_spent_height <= fork_height;
-        }
-    };
-
-    element_.read(reader);
-    return spent;
-}
+////bool transaction_result::is_confirmed_spent(size_t fork_height) const
+////{
+////    // Cannot be spent unless confirmed by fork height.
+////    if (!((position_ != unconfirmed) && (height_ <= fork_height)))
+////        return false;
+////
+////    BITCOIN_ASSERT(element_);
+////    auto spent = true;
+////
+////    // Spentness is unguarded and will be inconsistent during write.
+////    const auto reader = [&](byte_deserializer& deserial)
+////    {
+////        deserial.skip(metadata_size);
+////        const auto outputs = deserial.read_size_little_endian();
+////
+////        // Search all outputs for an unspent indication.
+////        for (auto out = 0u; spent && out < outputs; ++out)
+////        {
+////            // TODO: This reads full output, which is simple but not optimial.
+////            const auto output = output::factory(deserial, false);
+////            spent = output.metadata.confirmed_spent_height <= fork_height;
+////        }
+////    };
+////
+////    element_.read(reader);
+////    return spent;
+////}
 
 // If index is out of range returns default/invalid output (.value not_found).
 chain::output transaction_result::output(uint32_t index) const

--- a/src/unspent_outputs.cpp
+++ b/src/unspent_outputs.cpp
@@ -195,15 +195,23 @@ bool unspent_outputs::populate(const output_point& point,
         return false;
 
     ++hits_;
-    const auto height = transaction.height();
+    const auto prevout_height = transaction.height();
 
     // Populate the output metadata.
+
+    // Cache retains only confirmed/unconfirmed state unspent output state.
     prevout.candidate = false;
-    prevout.confirmed = transaction.is_confirmed() && height <= fork_height;
     prevout.candidate_spent = false;
+
+    // Cache removes outputs after they are confirmed spent.
     prevout.confirmed_spent = false;
+
+    // Unspent output is confirmed only if below the fork point.
+    prevout.confirmed = transaction.is_confirmed() &&
+        prevout_height <= fork_height;
+
+    prevout.height = prevout_height;
     prevout.coinbase = transaction.is_coinbase();
-    prevout.height = height;
     prevout.median_time_past = transaction.median_time_past();
     prevout.cache = output->second;
 

--- a/src/unspent_outputs.cpp
+++ b/src/unspent_outputs.cpp
@@ -198,9 +198,10 @@ bool unspent_outputs::populate(const output_point& point,
     const auto height = transaction.height();
 
     // Populate the output metadata.
-    prevout.spent = false;
     prevout.candidate = false;
     prevout.confirmed = transaction.is_confirmed() && height <= fork_height;
+    prevout.candidate_spent = false;
+    prevout.confirmed_spent = false;
     prevout.coinbase = transaction.is_coinbase();
     prevout.height = height;
     prevout.median_time_past = transaction.median_time_past();

--- a/test/databases/transaction_database.cpp
+++ b/test/databases/transaction_database.cpp
@@ -81,7 +81,6 @@ BOOST_AUTO_TEST_CASE(transaction_database__store1__single_transactions__success)
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
 
     instance.store(tx2, 200);
-
     const auto result2 = instance.get(hash2);
     BOOST_REQUIRE(result2);
     BOOST_REQUIRE(result2.transaction().hash() == hash2);
@@ -117,7 +116,6 @@ BOOST_AUTO_TEST_CASE(transaction_database__store2__list_of_transactions__success
     // Setup end
 
     instance.store({tx1, tx2});
-
     const auto result1 = instance.get(hash1);
     BOOST_REQUIRE(result1);
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
@@ -149,7 +147,6 @@ BOOST_AUTO_TEST_CASE(transaction_database__store1__single_unconfirmed__success)
     // Setup end
 
     instance.store(tx1, 1);
-
     const auto result1 = instance.get(hash1);
     BOOST_REQUIRE(result1);
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
@@ -204,7 +201,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__store2__list_of_unconfirmed__success)
 // Candidate/Uncandidate
 // ----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_no_input_in_db__candidate_spend_false)
+BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_no_input_in_db__candidate_spent_false)
 {
     transaction tx1;
     data_chunk wire_tx1;
@@ -224,11 +221,11 @@ BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_no_input_in_db__candi
 
     // Setup end
 
-    const bool result = instance.candidate(instance.get(hash1).link());
+    const auto result = instance.candidate(instance.get(hash1).link());
     BOOST_REQUIRE(!result);
 }
 
-BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_input_in_db__candidate_spend_true)
+BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_input_in_db__candidate_spent_true)
 {
     uint32_t version = 2345u;
     uint32_t locktime = 0xffffffff;
@@ -250,9 +247,9 @@ BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_input_in_db__candidat
 
     const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
     BOOST_REQUIRE(tx1.is_coinbase());
+
     const auto hash1 = tx1.hash();
     instance.store(tx1, 1);
-
     const auto result1 = instance.get(hash1);
     BOOST_REQUIRE(result1);
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
@@ -271,21 +268,19 @@ BOOST_AUTO_TEST_CASE(transaction_database__candidate__with_input_in_db__candidat
     const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
     const auto hash2 = tx2.hash();
     instance.store(tx2, 1);
-
     BOOST_REQUIRE(!result1.candidate());
-    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.candidate_spent);
 
     // Setup end
 
-    const bool result = instance.candidate(instance.get(hash2).link());
-    BOOST_REQUIRE(result);
+    BOOST_REQUIRE(instance.candidate(instance.get(hash2).link()));
 
     const auto tx2_reloaded = instance.get(hash2);
     BOOST_REQUIRE(tx2_reloaded.candidate());
 
     const auto tx1_reloaded = instance.get(hash1);
     BOOST_REQUIRE(!tx1_reloaded.candidate());
-    BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.candidate_spent);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_no_input_in_db__false)
@@ -301,18 +296,17 @@ BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_no_input_in_db__fal
 
     const auto hash1 = tx1.hash();
     instance.store(tx1, 1);
-
     const auto result1 = instance.get(hash1);
     BOOST_REQUIRE(result1);
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
 
     // Setup end
 
-    const bool result = instance.uncandidate(instance.get(hash1).link());
+    const auto result = instance.uncandidate(instance.get(hash1).link());
     BOOST_REQUIRE(!result);
 }
 
-BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_input_in_db__candidate_spend_true)
+BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_input_in_db__candidate_spent_true)
 {
     uint32_t version = 2345u;
     uint32_t locktime = 0xffffffff;
@@ -334,9 +328,9 @@ BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_input_in_db__candid
 
     const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
     BOOST_REQUIRE(tx1.is_coinbase());
+
     const auto hash1 = tx1.hash();
     instance.store(tx1, 1);
-
     const auto result1 = instance.get(hash1);
     BOOST_REQUIRE(result1);
     BOOST_REQUIRE(result1.transaction().hash() == hash1);
@@ -355,20 +349,17 @@ BOOST_AUTO_TEST_CASE(transaction_database__uncandidate__with_input_in_db__candid
     const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
     const auto hash2 = tx2.hash();
     instance.store(tx2, 1);
-
     BOOST_REQUIRE(!result1.candidate());
-    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.candidate_spent);
 
     // Setup end
 
-    const bool result = instance.uncandidate(instance.get(hash2).link());
-    BOOST_REQUIRE(result);
-
+    BOOST_REQUIRE(instance.uncandidate(instance.get(hash2).link()));
     BOOST_REQUIRE(!instance.get(hash2).candidate());
 
     const auto tx1_reloaded = instance.get(hash1);
     BOOST_REQUIRE(!tx1_reloaded.candidate());
-    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spent);
 }
 
 // Confirm
@@ -391,11 +382,10 @@ BOOST_AUTO_TEST_CASE(transaction_database__confirm2__single_transaction_not_in_d
 
     // Setup end
 
-    const bool result = instance.confirm(instance.get(hash1).link(), 123, 456, 789);
+    const auto result = instance.confirm(instance.get(hash1).link(), 123, 456, 789);
     BOOST_REQUIRE(!result);
 
     const auto tx1_reloaded = instance.get(hash1);
-
     BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), machine::rule_fork::unverified);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 0u);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), transaction_result::unconfirmed);
@@ -424,6 +414,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__confirm2__single_transaction_with_inp
 
     const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
     BOOST_REQUIRE(tx1.is_coinbase());
+
     const auto hash1 = tx1.hash();
     instance.store({tx1});
 
@@ -441,36 +432,38 @@ BOOST_AUTO_TEST_CASE(transaction_database__confirm2__single_transaction_with_inp
     const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
     const auto hash2 = tx2.hash();
     instance.store(tx2, 1);
+    BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spent);
 
-    BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spend);
-
-    BOOST_REQUIRE_EQUAL(instance.get(hash1).height(), machine::rule_fork::unverified);
-    BOOST_REQUIRE(!instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+    const auto result1 = instance.get(hash1);
+    BOOST_REQUIRE(result1);
+    BOOST_REQUIRE_EQUAL(result1.height(), machine::rule_fork::unverified);
+////    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.spent(123, false));
 
     // Setup end
 
-    const bool confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
+    const auto confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
     BOOST_REQUIRE(confirm1);
-    const bool confirm2 = instance.confirm(instance.get(hash2).link(), 123, 456, 789);
+
+    const auto confirm2 = instance.confirm(instance.get(hash2).link(), 123, 456, 789);
     BOOST_REQUIRE(confirm2);
 
     const auto tx2_reloaded = instance.get(hash2);
-
     BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), 123);
     BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 456);
     BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), 789);
     BOOST_REQUIRE(!tx2_reloaded.candidate());
-    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
     const auto tx1_reloaded = instance.get(hash1);
-
     BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 89);
     BOOST_REQUIRE(!tx1_reloaded.candidate());
 
-    BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height, 123);
-    BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+    const auto tx1_reloaded_tx = tx1_reloaded.transaction();
+    const auto& metadata = tx1_reloaded_tx.outputs().front().metadata;
+    BOOST_REQUIRE_EQUAL(metadata.confirmed_spent_height, 123);
+////    BOOST_REQUIRE(metadata.spent(123, false));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm2__single_transaction_with_inputs_in_db__success)
@@ -495,6 +488,7 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm2__single_transacti
 
     const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
     BOOST_REQUIRE(tx1.is_coinbase());
+
     const auto hash1 = tx1.hash();
     instance.store({tx1});
 
@@ -512,36 +506,37 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm2__single_transacti
     const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
     const auto hash2 = tx2.hash();
     instance.store(tx2, 1);
+    BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spent);
 
-    BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spend);
-
-    BOOST_REQUIRE_EQUAL(instance.get(hash1).height(), machine::rule_fork::unverified);
-    BOOST_REQUIRE(!instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+    const auto result1 = instance.get(hash1);
+    BOOST_REQUIRE_EQUAL(result1.height(), machine::rule_fork::unverified);
+////    BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.spent(123, false));
 
     // Setup end
 
-    const bool confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
+    const auto confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
     BOOST_REQUIRE(confirm1);
-    const bool confirm2 = instance.confirm(instance.get(hash2).link(), 123, 456, 789);
+
+    const auto confirm2 = instance.confirm(instance.get(hash2).link(), 123, 456, 789);
     BOOST_REQUIRE(confirm2);
 
     const auto tx2_reloaded = instance.get(hash2);
-
     BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), 123);
     BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 456);
     BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), 789);
     BOOST_REQUIRE(!tx2_reloaded.candidate());
-    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
     const auto tx1_reloaded = instance.get(hash1);
-
     BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
     BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 89);
     BOOST_REQUIRE(!tx1_reloaded.candidate());
 
-    BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height, 123);
-    BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+    const auto tx1_reloaded_tx = tx1_reloaded.transaction();
+    const auto& metadata = tx1_reloaded_tx.outputs().front().metadata;
+    BOOST_REQUIRE_EQUAL(metadata.confirmed_spent_height, 123);
+////    BOOST_REQUIRE(metadata.spent(123, false));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactions_with_inputs_in_db__success)
@@ -566,6 +561,7 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactio
 
    const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
    BOOST_REQUIRE(tx1.is_coinbase());
+
    const auto hash1 = tx1.hash();
    instance.store({tx1});
 
@@ -598,11 +594,12 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactio
    const chain::transaction tx3(version, locktime, tx3_inputs, tx3_outputs);
    const auto hash3 = tx3.hash();
    instance.store(tx3, 1);
+   BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spent);
 
-   BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spend);
-
-   BOOST_REQUIRE_EQUAL(instance.get(hash1).height(), machine::rule_fork::unverified);
-   BOOST_REQUIRE(!instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+   const auto result1 = instance.get(hash1);
+   BOOST_REQUIRE(result1);
+   BOOST_REQUIRE_EQUAL(result1.height(), machine::rule_fork::unverified);
+////   BOOST_REQUIRE(!result1.transaction().outputs().front().metadata.spent(123, false));
 
     const auto settings = system::settings(system::config::settings::mainnet);
     chain::block block0 = settings.genesis_block;
@@ -610,46 +607,40 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactio
 
     // Setup end
 
-   const bool confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
+   const auto confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
    BOOST_REQUIRE(confirm1);
 
    const auto tx1_reloaded = instance.get(hash1);
-
    BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
    BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
    BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 89);
    BOOST_REQUIRE(!tx1_reloaded.candidate());
 
-   const bool confirm2_3 = instance.confirm(block0, 123, 456);
+   const auto confirm2_3 = instance.confirm(block0, 123, 456);
    BOOST_REQUIRE(confirm2_3);
 
    const auto tx2_reloaded = instance.get(hash2);
-
    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), 123);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 456);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), 0);
    BOOST_REQUIRE(!tx2_reloaded.candidate());
-   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
    const auto tx3_reloaded = instance.get(hash3);
-
    BOOST_REQUIRE_EQUAL(tx3_reloaded.height(), 123);
    BOOST_REQUIRE_EQUAL(tx3_reloaded.median_time_past(), 456);
    BOOST_REQUIRE_EQUAL(tx3_reloaded.position(), 1);
    BOOST_REQUIRE(!tx3_reloaded.candidate());
-   BOOST_REQUIRE(!tx3_reloaded.transaction().outputs().front().metadata.candidate_spend);
+   BOOST_REQUIRE(!tx3_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
    const auto tx1_reloaded2 = instance.get(hash1);
-
    BOOST_REQUIRE_EQUAL(tx1_reloaded2.height(), 23);
    BOOST_REQUIRE_EQUAL(tx1_reloaded2.median_time_past(), 56);
    BOOST_REQUIRE_EQUAL(tx1_reloaded2.position(), 89);
    BOOST_REQUIRE(!tx1_reloaded2.candidate());
-
-   BOOST_REQUIRE_EQUAL(tx1_reloaded2.output(0).metadata.confirmed_spend_height, 123);
-   
-   BOOST_REQUIRE(tx1_reloaded2.transaction().outputs().front().metadata.spent(123, false));
-   BOOST_REQUIRE(tx1_reloaded2.is_spent(123, false));
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.output(0).metadata.confirmed_spent_height, 123);
+   ////   BOOST_REQUIRE(tx1_reloaded2.transaction().outputs().front().metadata.spent(123, false));
+   BOOST_REQUIRE(tx1_reloaded2.is_confirmed_spent(123));
 }
 
 // Unconfirm
@@ -700,7 +691,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__block_with_unconfirmed_txs
    
    // Setup end
 
-   const bool result = instance.unconfirm(block0);
+   const auto result = instance.unconfirm(block0);
    BOOST_REQUIRE(!result);
 }
 
@@ -747,8 +738,10 @@ BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__single_confirmed__success)
    instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 1);
    instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 1);
 
-   BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
-   BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+   const auto result1 = instance.get(hash1);
+   BOOST_REQUIRE(result1);
+   BOOST_REQUIRE_EQUAL(result1.transaction().outputs().front().metadata.confirmed_spent_height, 123);
+////   BOOST_REQUIRE(result1.transaction().outputs().front().metadata.spent(123, false));
 
    const auto settings = system::settings(system::config::settings::mainnet);
    chain::block block0 = settings.genesis_block;
@@ -756,28 +749,26 @@ BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__single_confirmed__success)
    
    // Setup end
 
-   const bool result = instance.unconfirm(block0);
-   BOOST_REQUIRE(result);
+   BOOST_REQUIRE(instance.unconfirm(block0));
 
    const auto tx2_reloaded = instance.get(hash2);
-
    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
    BOOST_REQUIRE(!tx2_reloaded.candidate());
-   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
    const auto tx1_reloaded = instance.get(hash1);
-
    BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
    BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
    BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 1);
    BOOST_REQUIRE(!tx1_reloaded.candidate());
-   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
+   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
-
-   BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height, machine::rule_fork::unverified);
-   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+   const auto tx1_reloaded_tx = tx1_reloaded.transaction();
+   const auto& metadata = tx1_reloaded_tx.outputs().front().metadata;
+   BOOST_REQUIRE_EQUAL(metadata.confirmed_spent_height, machine::rule_fork::unverified);
+////   BOOST_REQUIRE(!metadata.spent(123, false));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database_with_cache__unconfirm__single_confirmed__success)
@@ -819,12 +810,13 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__unconfirm__single_confirme
    const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
    const auto hash2 = tx2.hash();
    instance.store(tx2, 1);
-
    instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 1);
    instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 1);
 
-   BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
-   BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+   const auto tx1_reloaded1_tx = instance.get(hash1).transaction();
+   const auto& metadata1 = tx1_reloaded1_tx.outputs().front().metadata;
+   BOOST_REQUIRE_EQUAL(metadata1.confirmed_spent_height, 123);
+////   BOOST_REQUIRE(metadata1.spent(123, false));
 
    const auto settings = system::settings(system::config::settings::mainnet);
    chain::block block0 = settings.genesis_block;
@@ -832,28 +824,26 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__unconfirm__single_confirme
 
    // Setup end
 
-   const bool result = instance.unconfirm(block0);
-   BOOST_REQUIRE(result);
+   BOOST_REQUIRE(instance.unconfirm(block0));
 
    const auto tx2_reloaded = instance.get(hash2);
-
    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
    BOOST_REQUIRE(!tx2_reloaded.candidate());
-   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spent);
 
-   const auto tx1_reloaded = instance.get(hash1);
+   const auto tx1_reloaded2 = instance.get(hash1);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.height(), 23);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.median_time_past(), 56);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.position(), 1);
+   BOOST_REQUIRE(!tx1_reloaded2.candidate());
+   BOOST_REQUIRE(!tx1_reloaded2.transaction().outputs().front().metadata.candidate_spent);
 
-   BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
-   BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
-   BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 1);
-   BOOST_REQUIRE(!tx1_reloaded.candidate());
-   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
-
-
-   BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height, machine::rule_fork::unverified);
-   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+   const auto tx1_reloaded2_tx = tx1_reloaded2.transaction();
+   const auto& metadata2 = tx1_reloaded2_tx.outputs().front().metadata;
+   BOOST_REQUIRE_EQUAL(metadata2.confirmed_spent_height, machine::rule_fork::unverified);
+////   BOOST_REQUIRE(!metadata2.spent(123, false));
 }
 
 
@@ -1036,7 +1026,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__null_point__false)
 
     // setup end
 
-    BOOST_REQUIRE(!instance.get_output({ null_hash, point::null_index }, 1, false));
+    BOOST_REQUIRE(!instance.get_output({ null_hash, point::null_index }, 1));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__not_found__false)
@@ -1052,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__not_found__false)
 
     // setup end
 
-    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 0 }, 1, false));
+    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 0 }, 1));
 }
 
 
@@ -1070,7 +1060,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__genesis__false)
 
     // setup end
 
-    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 0 }, 1, false));
+    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 0 }, 1));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__no_output_at_index__false)
@@ -1086,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__no_output_at_index__false
 
     instance.store(tx1, 100);
 
-    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 1 }, 1, false));
+    BOOST_REQUIRE(!instance.get_output({ tx1.hash(), 1 }, 1));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__unconfirmed_at_fork_height__unconfirmed)
@@ -1104,13 +1094,13 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__unconfirmed_at_fork_heigh
 
     output_point point{ tx1.hash(), 0 };
 
-    BOOST_REQUIRE(instance.get_output(point, 101, false));
+    BOOST_REQUIRE(instance.get_output(point, 101));
     BOOST_REQUIRE(!point.metadata.coinbase);
     BOOST_REQUIRE(!point.metadata.candidate);
     BOOST_REQUIRE(!point.metadata.confirmed);
     BOOST_REQUIRE_EQUAL(point.metadata.height, 100);
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 0);
-    BOOST_REQUIRE(!point.metadata.spent);
+    BOOST_REQUIRE(!point.metadata.confirmed_spent);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__confirmed_at_height__confirmed)
@@ -1134,13 +1124,13 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__confirmed_at_height__conf
 
     output_point point{ tx1.hash(), 0 };
 
-    BOOST_REQUIRE(instance.get_output(point, 123, false));
+    BOOST_REQUIRE(instance.get_output(point, 123));
     BOOST_REQUIRE(point.metadata.coinbase);
     BOOST_REQUIRE(!point.metadata.candidate);
     BOOST_REQUIRE(point.metadata.confirmed);
     BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
-    BOOST_REQUIRE(!point.metadata.spent);
+    BOOST_REQUIRE(!point.metadata.confirmed_spent);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database_with_cache__get_output__confirmed_at_height__confirmed)
@@ -1164,13 +1154,13 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__get_output__confirmed_at_h
 
    output_point point{ tx1.hash(), 0 };
 
-   BOOST_REQUIRE(instance.get_output(point, 123, false));
+   BOOST_REQUIRE(instance.get_output(point, 123));
    BOOST_REQUIRE(!point.metadata.coinbase);
    BOOST_REQUIRE(!point.metadata.candidate);
    BOOST_REQUIRE(point.metadata.confirmed);
    BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
    BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
-   BOOST_REQUIRE(!point.metadata.spent);
+   BOOST_REQUIRE(!point.metadata.confirmed_spent);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__unconfirmed_at_height__unconfirmed)
@@ -1197,13 +1187,13 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__unconfirmed_at_height__un
 
     output_point point{ tx2.hash(), 0 };
 
-    BOOST_REQUIRE(instance.get_output(point, 100, false));
+    BOOST_REQUIRE(instance.get_output(point, 100));
     BOOST_REQUIRE(!point.metadata.coinbase);
     BOOST_REQUIRE(!point.metadata.candidate);
     BOOST_REQUIRE(!point.metadata.confirmed);
     BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
-    BOOST_REQUIRE(!point.metadata.spent);
+    BOOST_REQUIRE(!point.metadata.confirmed_spent);
 }
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__prevout_spent__spent)
@@ -1234,21 +1224,21 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__prevout_spent__spent)
 
     output_point point{ tx1.hash(), 0 };
 
-    BOOST_REQUIRE(instance.get_output(point, 1229, false));
+    BOOST_REQUIRE(instance.get_output(point, 1229));
     BOOST_REQUIRE(point.metadata.coinbase);
     BOOST_REQUIRE(!point.metadata.candidate);
     BOOST_REQUIRE(point.metadata.confirmed);
     BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
-    BOOST_REQUIRE(!point.metadata.spent);
+    BOOST_REQUIRE(!point.metadata.confirmed_spent);
 
-    BOOST_REQUIRE(instance.get_output(point, 1230, false));
+    BOOST_REQUIRE(instance.get_output(point, 1230));
     BOOST_REQUIRE(point.metadata.coinbase);
     BOOST_REQUIRE(!point.metadata.candidate);
     BOOST_REQUIRE(point.metadata.confirmed);
     BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
-    BOOST_REQUIRE(point.metadata.spent);
+    BOOST_REQUIRE(point.metadata.confirmed_spent);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/databases/transaction_database.cpp
+++ b/test/databases/transaction_database.cpp
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactio
    BOOST_REQUIRE(!tx1_reloaded2.candidate());
    BOOST_REQUIRE_EQUAL(tx1_reloaded2.output(0).metadata.confirmed_spent_height, 123);
    ////   BOOST_REQUIRE(tx1_reloaded2.transaction().outputs().front().metadata.spent(123, false));
-   BOOST_REQUIRE(tx1_reloaded2.is_confirmed_spent(123));
+   BOOST_REQUIRE(tx1_reloaded2.is_candidate_spent(123));
 }
 
 // Unconfirm

--- a/test/unspent_outputs.cpp
+++ b/test/unspent_outputs.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(unspent_outputs__remove2__remove_one_output__expected_outpu
     BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, expected_median_time_past);
     BOOST_REQUIRE_EQUAL(point.metadata.confirmed, expected_confirmed);
     BOOST_REQUIRE(!point.metadata.coinbase);
-    BOOST_REQUIRE(!point.metadata.spent);
+    BOOST_REQUIRE(!point.metadata.confirmed_spent);
 
     cache.remove({ tx1.hash(), 1 });
     BOOST_REQUIRE_EQUAL(cache.size(), 2u);


### PR DESCRIPTION
Fixes invalid tx validation double-spend errors.