### PR TITLE
Add support for transaction deconfirmation and setting tx.metadata.cataloged

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Bitcoin High Performance Blockchain Database*
 
-Make sure you have installed [libbitcoin](https://github.com/libbitcoin/libbitcoin) beforehand according to its build instructions.
+Make sure you have installed [libbitcoin](https://github.com/libbitcoin/libbitcoin-system) beforehand according to its build instructions.
 
 ```sh
 $ ./autogen.sh

--- a/include/bitcoin/database/result/transaction_result.hpp
+++ b/include/bitcoin/database/result/transaction_result.hpp
@@ -52,6 +52,9 @@ public:
     /// This is unconfirmed tx position sentinel.
     static const uint16_t unconfirmed;
 
+    /// This is deconfirmed tx position sentinel.
+    static const uint16_t deconfirmed;
+
     transaction_result(const const_element_type& element,
         system::shared_mutex& metadata_mutex);
 
@@ -64,10 +67,10 @@ public:
     /// The transaction hash (from cache).
     system::hash_digest hash() const;
 
-    /// The height of the block of the tx, or forks if unconfirmed.
+    /// The height of the block of the tx, or forks if unconfirmed or deconfirmed.
     size_t height() const;
 
-    /// The ordinal position of the tx in a block, or unconfirmed.
+    /// The ordinal position of the tx in a block, or unconfirmed or deconfirmed.
     size_t position() const;
 
     /// The transaction is in a candidate block.

--- a/src/data_base.cpp
+++ b/src/data_base.cpp
@@ -247,7 +247,7 @@ code data_base::catalog(const transaction& tx)
     code ec;
 
     // Existence check prevents duplicated indexing.
-    if (!catalog_ || tx.metadata.existed)
+    if (!catalog_ || tx.metadata.cataloged)
         return ec;
 
     // Critical Section
@@ -289,7 +289,7 @@ code data_base::catalog(const block& block)
 
     // Existence check prevents duplicated indexing.
     for (const auto& tx: block.transactions())
-        if (!tx.metadata.existed)
+        if (!tx.metadata.cataloged)
             addresses_->catalog(tx);
 
     addresses_->commit();

--- a/src/databases/address_database.cpp
+++ b/src/databases/address_database.cpp
@@ -149,7 +149,7 @@ void address_database::store(const hash_digest& script_hash, const point& point,
 void address_database::catalog(const transaction& tx)
 {
     BITCOIN_ASSERT(tx.metadata.link);
-    BITCOIN_ASSERT(!tx.metadata.existed);
+    BITCOIN_ASSERT(!tx.metadata.cataloged);
 
     const auto tx_hash = tx.hash();
     const auto link = tx.metadata.link;

--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -539,9 +539,8 @@ bool transaction_database::confirmed_spend(const output_point& point,
         return false;
 
     // Use not_spent as the spender_height for output.
-    if (spender_height == rule_fork::unverified) {
+    if (spender_height == rule_fork::unverified)
         spender_height = output::validation::not_spent;
-    }
 
     const auto writer = [&](byte_serializer& serial)
     {

--- a/src/databases/transaction_database.cpp
+++ b/src/databases/transaction_database.cpp
@@ -36,7 +36,7 @@ using namespace bc::system::machine;
 // Record format (v4):
 // ----------------------------------------------------------------------------
 // [ height/forks/code:4 - atomic1  ] (code if invalid)
-// [ position:2          - atomic1  ] (unconfirmed sentinel, could store state)
+// [ position:2          - atomic1  ] (unconfirmed/deconfirmed sentinel, could store state)
 // [ candidate:1         - atomic1  ] (candidate(1))
 // [ median_time_past:4  - atomic1  ] (zero if unconfirmed)
 // [ output_count:varint - const    ] (tx starts here)
@@ -153,6 +153,7 @@ void transaction_database::get_block_metadata(const chain::transaction& tx,
 {
     static const auto unlinked = transaction::validation::unlinked;
     static const auto unconfirmed = transaction_result::unconfirmed;
+    static const auto deconfirmed = transaction_result::deconfirmed;
     const auto result = get(tx.hash());
 
     // Default values are correct for indication of not found.
@@ -178,13 +179,17 @@ void transaction_database::get_block_metadata(const chain::transaction& tx,
 
     const auto height = result.height();
     const auto is_linked = result.link() != unlinked;
-    const auto has_position = result.position() != unconfirmed;
+    const auto has_position = result.position() != unconfirmed &&
+        result.position() != deconfirmed;
     const auto is_confirmed = has_position && fork_height <= height;
+    const auto is_cataloged =  result.position() != unconfirmed &&
+        fork_height <= height;
 
     tx.metadata.existed = is_linked;
     tx.metadata.link = result.link();
     tx.metadata.candidate = result.candidate();
     tx.metadata.confirmed = is_confirmed;
+    tx.metadata.cataloged = is_cataloged;
     tx.metadata.verified = !is_confirmed && height == forks;
 }
 
@@ -193,6 +198,7 @@ void transaction_database::get_pool_metadata(const chain::transaction& tx,
 {
     static const auto unlinked = transaction::validation::unlinked;
     static const auto unconfirmed = transaction_result::unconfirmed;
+    static const auto deconfirmed = transaction_result::deconfirmed;
     const auto result = get(tx.hash());
 
     // Default values presumed correct for indication of not found.
@@ -201,12 +207,15 @@ void transaction_database::get_pool_metadata(const chain::transaction& tx,
 
     const auto height = result.height();
     const auto is_linked = result.link() != unlinked;
-    const auto is_confirmed = result.position() != unconfirmed;
+    const auto is_confirmed = result.position() != unconfirmed &&
+        result.position() != deconfirmed;
+    const auto is_cataloged =  result.position() != unconfirmed;
 
     tx.metadata.existed = is_linked;
     tx.metadata.link = result.link();
     tx.metadata.candidate = result.candidate();
     tx.metadata.confirmed = is_confirmed;
+    tx.metadata.cataloged = is_cataloged;
     tx.metadata.verified = !is_confirmed && height == forks;
 }
 
@@ -216,6 +225,7 @@ bool transaction_database::get_output(const output_point& point,
 {
     static const auto not_spent = output::validation::not_spent;
     static const auto unconfirmed = transaction_result::unconfirmed;
+    static const auto deconfirmed = transaction_result::deconfirmed;
     auto& prevout = point.metadata;
 
     // If the input is a coinbase there is no prevout to populate.
@@ -246,7 +256,8 @@ bool transaction_database::get_output(const output_point& point,
 
     const auto position = result.position();
     const auto first_position = position == 0;
-    const auto has_position = position != unconfirmed;
+    const auto has_position = position != unconfirmed &&
+        position != deconfirmed;
     const auto spender_height = prevout.cache.metadata.confirmed_spent_height;
 
     // Populate output metadata relative to the fork point.
@@ -473,12 +484,13 @@ bool transaction_database::confirm(const block& block, size_t height,
     return true;
 }
 
+// Should only be called for a confirmed block
 bool transaction_database::unconfirm(const block& block)
 {
     for (const auto& tx: block.transactions())
     {
         if (!confirm(tx.metadata.link, rule_fork::unverified, no_time,
-            transaction_result::unconfirmed))
+            transaction_result::deconfirmed))
             return false;
 
         // Uncache the unspent outputs of the unconfirmed transaction.
@@ -525,6 +537,11 @@ bool transaction_database::confirmed_spend(const output_point& point,
     // The index is not in the transaction.
     if (point.index() >= outputs)
         return false;
+
+    // Use not_spent as the spender_height for output.
+    if (spender_height == rule_fork::unverified) {
+        spender_height = output::validation::not_spent;
+    }
 
     const auto writer = [&](byte_serializer& serial)
     {

--- a/src/unspent_outputs.cpp
+++ b/src/unspent_outputs.cpp
@@ -89,8 +89,9 @@ void unspent_outputs::add(const transaction& tx, size_t height,
     if (unspent_.size() >= capacity_)
         unspent_.right.erase(unspent_.right.begin());
 
-    // TODO: promote the unconfirmed tx cache instead of replacing it.
-    // A confirmed tx may replace the same unconfirmed tx here.
+    // TODO: promote the unconfirmed/deconfirmed tx cache instead of
+    // replacing it.  A confirmed tx may replace the same
+    // unconfirmed/deconfirmed tx here.
     unspent_.insert(
     {
         unspent_transaction{ tx, height, median_time_past, confirmed },

--- a/test/data_base.cpp
+++ b/test/data_base.cpp
@@ -53,10 +53,11 @@ static void test_outputs_cataloged(const address_database& payments_store,
                 return;
             }
         }
-
-        BOOST_REQUIRE(!expect_found);
         ++output_index;
     }
+
+    // Reached only if expected to not found output in address database.
+    BOOST_REQUIRE(!expect_found);    
 }
 
 static void test_inputs_cataloged(const address_database& payments_store,
@@ -80,10 +81,11 @@ static void test_inputs_cataloged(const address_database& payments_store,
                 return;
             }
         }
-
-        BOOST_REQUIRE(!expect_found);
         ++input_index;
     }
+
+    // Reached only if expected to not found output in address database.
+    BOOST_REQUIRE(!expect_found);    
 }
 
 static void test_block_exists(const data_base& interface, size_t height,
@@ -238,6 +240,11 @@ BOOST_FIXTURE_TEST_SUITE(data_base_tests, data_base_setup_fixture)
 "6c5b1629ecf97fff95d7a4bbdac87cc26099ada28066c6ff1eb9191223cd897194a08d0c272" \
 "6c5747f1db49e8cf90e75dc3e3550ae9b30086f3cd5aaac00000000"
 
+#define INPUT1 "0 [51]"
+#define OUTPUT1 "hash160 [da1745e9b549bd0bfa1a569971c77eba30cd5a4b] equal"
+#define INPUT2 "[1.] [0.51]"
+#define OUTPUT2 "hash160 [da1745e9b549bd0bfa1a569971c77eba30cd5a4b] equal"
+
 class data_base_accessor
   : public data_base
 {
@@ -385,11 +392,11 @@ BOOST_AUTO_TEST_CASE(data_base__push__adds_to_blocks_and_transactions_validates_
 
     const auto block1 = read_block(MAINNET_BLOCK1);   
 
-    // setup ends
+    // Setup ends.
    
     BOOST_REQUIRE_EQUAL(instance.push(block1, 1), error::success);
 
-    // test conditions
+    // Test conditions.
    
     test_block_exists(instance, 1, block1, true, false);
     test_heights(instance, 1u, 1u);
@@ -417,11 +424,11 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__not_existing___failure)
     const auto block1 = read_block(MAINNET_BLOCK1);
     store_block_transactions(instance, block1, 1);
     
-    // setup ends
+    // Setup ends.
     
     BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::operation_failed);
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 0u, 0u);
 }
@@ -449,7 +456,7 @@ BOOST_AUTO_TEST_CASE(data_base__push_block__incorrect_height___failure)
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
     test_heights(instance, 1u, 0u);
 
-    // setup ends
+    // Setup ends.
 
 #ifndef NDEBUG
     BOOST_REQUIRE_EQUAL(instance.push_block(block1, 2), error::store_block_invalid_height);
@@ -478,7 +485,7 @@ BOOST_AUTO_TEST_CASE(data_base__push_header__missing_parent___failure)
     store_block_transactions(instance, block1, 1);
     block1.set_header(chain::header{});
 
-    // setup ends
+    // Setup ends.
 
 #ifndef NDEBUG
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::store_block_missing_parent);
@@ -510,12 +517,12 @@ BOOST_AUTO_TEST_CASE(data_base__push_block_and_update__already_candidated___succ
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
     test_heights(instance, 1u, 0u);
 
-    // setup ends
+    // Setup ends.
    
     BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
     BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 1u, 1u);
     test_block_exists(instance, 1, block1, false, false);
@@ -539,7 +546,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_header_not_top___failure)
    
     const auto block1 = read_block(MAINNET_BLOCK1);
 
-    // setup ends
+    // Setup ends.
 
     chain::header out_header;
     BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::operation_failed);
@@ -567,12 +574,12 @@ BOOST_AUTO_TEST_CASE(data_base__pop_header__candidate___success)
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
 
-    // setup ends
+    // Setup ends.
 
     chain::header out_header;
     BOOST_REQUIRE_EQUAL(instance.pop_header(out_header, 1), error::success);
 
-    // test conditions
+    // Test conditions.
 
     BOOST_REQUIRE(out_header.hash() == block1.header().hash());
     test_heights(instance, 0u, 0u);
@@ -596,7 +603,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_block_not_top___failure)
 
     const auto block1 = read_block(MAINNET_BLOCK1);
 
-    // setup ends
+    // Setup ends.
 
     chain::block out_block;
     BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::operation_failed);
@@ -625,12 +632,12 @@ BOOST_AUTO_TEST_CASE(data_base__pop_block__confirmed___success)
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
     BOOST_REQUIRE_EQUAL(instance.push_block(block1, 1), error::success);
 
-    // setup ends
+    // Setup ends.
 
     chain::block out_block;
     BOOST_REQUIRE_EQUAL(instance.pop_block(out_block, 1), error::success);
 
-    // test conditions
+    // Test conditions.
 
     BOOST_REQUIRE(out_block.hash() == block1.hash());
     test_block_not_exists(instance, block1, false);
@@ -679,14 +686,14 @@ BOOST_AUTO_TEST_CASE(data_base__push_all_and_update__already_candidated___succes
     
     test_heights(instance, 3u, 0u);
     
-    // setup ends
+    // Setup ends.
     
     BOOST_REQUIRE(instance.push_all(blocks_push_ptr, config::checkpoint(genesis.hash(), 0)));
     BOOST_REQUIRE_EQUAL(instance.update(*block1_ptr, 1), error::success);
     BOOST_REQUIRE_EQUAL(instance.update(*block2_ptr, 2), error::success);
     BOOST_REQUIRE_EQUAL(instance.update(*block3_ptr, 3), error::success);
     
-    // test conditions
+    // Test conditions.
     
     test_heights(instance, 3u, 3u);
     test_block_exists(instance, 1, *block1_ptr, false, false);
@@ -713,7 +720,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above_missing_forkpoint_hash___failure)
     const auto block1 = read_block(MAINNET_BLOCK1);
     const auto out_headers = std::make_shared<header_const_ptr_list>();
 
-    // setup ends
+    // Setup ends.
 
     const auto result = instance.pop_above(out_headers, config::checkpoint(block1.hash(), 0));
 #ifndef NDEBUG
@@ -744,7 +751,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__wrong_forkpoint_height___failure)
     const auto block1 = read_block(MAINNET_BLOCK1);
     const auto out_headers = std::make_shared<header_const_ptr_list>();
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE(!instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 10)));
 }
@@ -770,11 +777,11 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__pop_zero___success)
     const auto block1 = read_block(MAINNET_BLOCK1);
     const auto out_headers = std::make_shared<header_const_ptr_list>();
 
-    // setup ends
+    // Setup ends.
    
     BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 0u, 0u);   
 }
@@ -819,12 +826,12 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above__candidated_not_confirmed___success)
 
     test_heights(instance, 3u, 0u);
 
-    // setup ends
+    // Setup ends.
    
     const auto out_headers = std::make_shared<header_const_ptr_list>();
     BOOST_REQUIRE(instance.pop_above(out_headers, config::checkpoint(genesis.hash(), 0)));
 
-    // test conditions
+    // Test conditions.
 
     BOOST_REQUIRE_EQUAL(out_headers->size(), 3);
     test_heights(instance, 0u, 0u);
@@ -854,7 +861,7 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__wrong_forkpoint_height___failure)
     const auto block1 = read_block(MAINNET_BLOCK1);
     const auto out_blocks = std::make_shared<block_const_ptr_list>();
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE(!instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 10)));
 }
@@ -880,11 +887,11 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__pop_zero___success)
     const auto block1 = read_block(MAINNET_BLOCK1);
     const auto out_blocks = std::make_shared<block_const_ptr_list>();
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 0u, 0u);
 }
@@ -936,12 +943,12 @@ BOOST_AUTO_TEST_CASE(data_base__pop_above2__confirmed___success)
 
     test_heights(instance, 3u, 3u);
 
-    // setup ends
+    // Setup ends.
 
     const auto out_blocks = std::make_shared<block_const_ptr_list>();
     BOOST_REQUIRE(instance.pop_above(out_blocks, config::checkpoint(genesis.hash(), 0)));
 
-    // test conditions
+    // Test conditions.
 
     BOOST_REQUIRE_EQUAL(out_blocks->size(), 3);
     test_heights(instance, 3u, 0u);
@@ -971,11 +978,11 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__not_existing___failure)
     const auto block1 = read_block(MAINNET_BLOCK1);
     store_block_transactions(instance, block1, 1);
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 0u, 0u);
 }
@@ -1003,7 +1010,7 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__incorrect_height___failure)
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
     test_heights(instance, 1u, 0u);
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 2), error::operation_failed);
 }
@@ -1028,7 +1035,7 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__missing_parent___failure)
     store_block_transactions(instance, block1, 1);
     block1.set_header(chain::header{});
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::operation_failed);
 }
@@ -1059,11 +1066,11 @@ BOOST_AUTO_TEST_CASE(data_base__confirm__already_candidated___success)
     BOOST_REQUIRE_EQUAL(block1.transactions().size(), 1);
     BOOST_REQUIRE_EQUAL(instance.blocks().get(1, true).transaction_count(), 1);
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.confirm(block1.hash(), 1), error::success);
 
-    // test conditions
+    // Test conditions.
 
     test_heights(instance, 1u, 1u);
     const auto block_result = instance.blocks().get(1, false);
@@ -1100,7 +1107,7 @@ BOOST_AUTO_TEST_CASE(data_base__update__incorrect_height__failure)
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
     BOOST_REQUIRE_EQUAL(instance.candidate(block1), error::success);
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.update(block1, 2), error::not_found);
 }
@@ -1135,16 +1142,16 @@ BOOST_AUTO_TEST_CASE(data_base__update__new_transactions__success)
 
     block1.set_transactions({ tx1 });
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.update(block1, 1), error::success);
 
-    // new transactions are not candidated
+    // New transactions are not candidated.
     const auto found = instance.transactions().get(tx1.hash());
     BOOST_REQUIRE(found);
     BOOST_REQUIRE(!instance.transactions().get(tx1.hash()).candidate());
 
-    // get block and check block_result can access transactions
+    // Get block and check block_result can access transactions.
     const auto block_result = instance.blocks().get(block1.hash());
     for (const auto& offset: block_result)
         BOOST_REQUIRE(!instance.transactions().get(offset).candidate());
@@ -1171,7 +1178,7 @@ BOOST_AUTO_TEST_CASE(data_base__invalidate__missing_header__failure)
 
     const auto block1 = read_block(MAINNET_BLOCK1);
 
-    // setup ends
+    // Setup ends.
     BOOST_REQUIRE_EQUAL(instance.invalidate(block1.header(), error::success), error::not_found);
 }
 #endif
@@ -1197,7 +1204,7 @@ BOOST_AUTO_TEST_CASE(data_base__invalidate__validate__success)
 
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
 
-    // setup ends
+    // Setup ends.
 
     const auto header_result = block1.header();
     BOOST_REQUIRE_EQUAL(instance.invalidate(header_result, error::success), error::success);
@@ -1229,7 +1236,7 @@ BOOST_AUTO_TEST_CASE(data_base__invalidate__invalidate__success)
 
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
 
-    // setup ends
+    // Setup ends.
 
     const auto header_result = block1.header();
     BOOST_REQUIRE_EQUAL(instance.invalidate(header_result, error::invalid_proof_of_work), error::success);
@@ -1262,13 +1269,18 @@ BOOST_AUTO_TEST_CASE(data_base__catalog__enabled__success)
     store_block_transactions(instance, block1, 1);
 
     BOOST_REQUIRE_EQUAL(instance.push_header(block1.header(), 1, 100), error::success);
-    // setup ends
+
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.catalog(block1), error::success);
 
-    // Coinbase transactions' inputs are not cataloged
+    // Coinbase transaction inputs are not cataloged
     BOOST_REQUIRE(block1.transactions().front().is_coinbase());
+    test_inputs_cataloged(instance.addresses(), block1.transactions().front(), false);
     test_outputs_cataloged(instance.addresses(), block1.transactions().front(), true);
+
+    // Second catalog attempt should fail.
+    BOOST_REQUIRE(!instance.catalog(block1));
 }
 
 // catalog transactions
@@ -1292,13 +1304,144 @@ BOOST_AUTO_TEST_CASE(data_base__catalog2__enabled__success)
     const auto block1 = read_block(MAINNET_BLOCK1);
     store_block_transactions(instance, block1, 1);
 
-    // setup ends
+    // Setup ends.
 
     BOOST_REQUIRE_EQUAL(instance.catalog(block1.transactions()[0]), error::success);
 
-    // Coinbase transactions' inputs are not cataloged
+    // Coinbase transaction inputs are not cataloged.
     BOOST_REQUIRE(block1.transactions().front().is_coinbase());
+    test_inputs_cataloged(instance.addresses(), block1.transactions().front(), false);
+
+    // Outputs are cataloged.
     test_outputs_cataloged(instance.addresses(), block1.transactions().front(), true);
+}
+
+BOOST_AUTO_TEST_CASE(data_base__catalog2__catalog_after_read__success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings, true);
+
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    const auto block1 = read_block(MAINNET_BLOCK2);
+    store_block_transactions(instance, block1, 1);
+    BOOST_REQUIRE_EQUAL(instance.catalog(block1.transactions()[0]), error::success);
+    auto reloaded_result = instance.transactions().get(block1.transactions()[0].hash());
+    auto reloaded = reloaded_result.transaction();
+
+    // Setup ends.
+
+    BOOST_REQUIRE_EQUAL(instance.catalog(reloaded), error::success);
+    
+    // Coinbase transaction inputs are not cataloged.
+    BOOST_REQUIRE(block1.transactions().front().is_coinbase());
+    test_inputs_cataloged(instance.addresses(), block1.transactions().front(), false);
+
+    // Outputs are cataloged.
+    test_outputs_cataloged(instance.addresses(), block1.transactions().front(), true);
+
+    // Second catalog attempt should fail.
+    BOOST_REQUIRE(!instance.catalog(reloaded));
+}
+
+BOOST_AUTO_TEST_CASE(data_base__catalog2__catalog_inputs_and_ouputs__success)
+{
+    create_directory(DIRECTORY);
+    bc::database::settings settings;
+    settings.directory = DIRECTORY;
+    settings.flush_writes = false;
+    settings.file_growth_rate = 42;
+    settings.block_table_buckets = 42;
+    settings.transaction_table_buckets = 42;
+    settings.address_table_buckets = 42;
+
+    data_base_accessor instance(settings, true);
+
+    const auto bc_settings = bc::system::settings(config::settings::mainnet);
+    BOOST_REQUIRE(instance.create(bc_settings.genesis_block));
+
+    uint32_t version = 2345u;
+    uint32_t locktime = 0xffffffff;
+    
+    script script_input1;
+    BOOST_REQUIRE(script_input1.from_string(INPUT1));
+
+    // tx1: coinbase transaction
+    const chain::input::list tx1_inputs
+    {
+        { chain::point{ null_hash, chain::point::null_index }, script_input1, 0 }
+    };
+    
+    script script_output1;
+    BOOST_REQUIRE(script_output1.from_string(OUTPUT1));
+    const chain::output::list tx1_outputs
+    {
+        { 1200, script_output1 }
+    };
+
+    const chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
+    BOOST_REQUIRE(tx1.is_coinbase());
+    const auto hash1 = tx1.hash();
+    instance.store(tx1, 1);
+    
+    script script_input2;
+    BOOST_REQUIRE(script_input2.from_string(INPUT2));
+
+    // tx2: spends coinbase, tx1 as input
+    const chain::input::list tx2_inputs
+    {
+        { { hash1, 0 }, script_input2, 0 }
+    };
+
+    // Set output cache for prevout so catalog has access to the script.
+    tx2_inputs.front().previous_output().metadata.cache = tx1_outputs.front();
+
+    script script_output2;
+    BOOST_REQUIRE(script_output2.from_string(OUTPUT2));
+
+    const chain::output::list tx2_outputs
+    {
+        { 1200, script_output2 }
+    };
+    
+    const chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
+    instance.store(tx2, 1);
+    BOOST_REQUIRE(tx2.inputs().front().previous_output().metadata.cache.is_valid());
+
+    test_inputs_cataloged(instance.addresses(), tx1, false);
+    test_outputs_cataloged(instance.addresses(), tx1, false);
+
+    test_inputs_cataloged(instance.addresses(), tx2, false);
+    test_outputs_cataloged(instance.addresses(), tx2, false);
+
+    // Setup ends.
+    
+    BOOST_REQUIRE_EQUAL(instance.catalog(tx1), error::success);
+
+    BOOST_REQUIRE(!tx1.metadata.cataloged);
+    BOOST_REQUIRE(tx1.is_coinbase());
+    test_inputs_cataloged(instance.addresses(), tx1, false);
+    test_outputs_cataloged(instance.addresses(), tx1, true);
+
+    test_inputs_cataloged(instance.addresses(), tx2, false);
+    test_outputs_cataloged(instance.addresses(), tx2, false);
+
+    BOOST_REQUIRE_EQUAL(instance.catalog(tx2), error::success);
+
+    test_inputs_cataloged(instance.addresses(), tx1, false);
+    test_outputs_cataloged(instance.addresses(), tx1, true);
+    BOOST_REQUIRE(!tx2.is_coinbase());
+    test_inputs_cataloged(instance.addresses(), tx2, true);
+    test_outputs_cataloged(instance.addresses(), tx2, true);
 }
 
 /// reorganize headers
@@ -1341,11 +1484,11 @@ BOOST_AUTO_TEST_CASE(data_base__reorganize__pop_and_push__success)
         std::make_shared<const message::header>(block3.header())
     });
 
-    // setup ends
+    // Setup ends.
     
     BOOST_REQUIRE_EQUAL(instance.reorganize(config::checkpoint(genesis.hash(), 0), incoming_headers, outgoing_headers), error::success);
 
-    // test conditions
+    // Test conditions.
     
     test_heights(instance, 2u, 0u);
 
@@ -1430,11 +1573,11 @@ BOOST_AUTO_TEST_CASE(data_base__reorganize2__pop_and_push__success)
         std::make_shared<const message::block>(block3)
     });
 
-    // setup ends
+    // Setup ends.
     
     BOOST_REQUIRE_EQUAL(instance.reorganize(config::checkpoint(genesis.hash(), 0), incoming_blocks, outgoing_blocks), error::success);
 
-    // test conditions
+    // Test conditions.
     
     test_heights(instance, 2u, 2u);
 

--- a/test/databases/transaction_database.cpp
+++ b/test/databases/transaction_database.cpp
@@ -753,9 +753,7 @@ BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__spent_across_blocks__succe
    instance.store(tx2, 1);
 
    instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 1);
-   tx1.metadata.confirmed = true;
    instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 1);
-   tx2.metadata.confirmed = true;
 
    const auto result1 = instance.get(hash1);
    BOOST_REQUIRE(result1);


### PR DESCRIPTION
- set tx.metadata.cataloged if confirmed once, and track deconfirmation separately so that cataloged can be derived correctly.

- update regression tests for unconfirm

- fix use of unverified instead of not_spent in unpsending outputs. @evoskuil - I spotted that on unconfirm we were setting previous output's spender_height to machine::rule_fork::unverified. However at the time of setting point.metadata.confirmed_spent in transaction_database::get_output we were correctly comparing with output::validation::not_spent. I made the required change to set output metadata' confirmed_spent_height to not_spent instead.

- add tests to unspend transactions from different blocks on unconfirm

- add test get metadata of prevout of a deconfirmed tx

EDIT: data_base#catalog now check tx.metadata.cataloged instead of tx.metadata.existed. Have included tests to capture this change.