### PR TITLE
Replace ftruncate with fallocate

### DIFF
--- a/src/memory/map.cpp
+++ b/src/memory/map.cpp
@@ -558,7 +558,7 @@ bool map::remap_(size_t size) NOEXCEPT
 bool map::resize_(size_t size) NOEXCEPT
 {
     // Disk full detection is platform common, any other failure is an abort.
-    if (::ftruncate(opened_, size) == fail)
+    if (::fallocate(opened_, 0, capacity_, size - capacity_) == fail)
     {
         // Disk full is the only restartable store failure (leave mapped).
         if (errno == ENOSPC)


### PR DESCRIPTION
Replace ftruncate with fallocate in map::resize_ to preallocate disk blocks, fix sparse file handling and ensure proper ENOSPC handling